### PR TITLE
ci: set NRFUTIL_HOME to shared location

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,6 @@ jobs:
 
       - name: Set up nrfutil
         run: |
-          ln -s /root/.nrfutil $HOME/.nrfutil
           nrfutil list
           nrfutil toolchain-manager list
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ RUN <<EOT
 EOT
 
 # Install toolchain
+# Make nrfutil install in a shared location, because when used with GitHub
+# Actions, the image will be launched with the home dir mounted from the local
+# checkout.
+ENV NRFUTIL_HOME=/usr/local/share/nrfutil
+# Install toolchain
 RUN <<EOT
     wget -q https://developer.nordicsemi.com/.pc-tools/nrfutil/x64-linux/nrfutil
     mv nrfutil /usr/local/bin


### PR DESCRIPTION
nrfutil toolchain-manager installs in `~/.nrfutil`, however when preparing a Docker image for GitHub Actions, they will launch into the Container, setting `$HOME` to `/home/github` and mounting the local filesystem over `/home/github`, so the `.nrfutil` folder is no longer visible. 

This sets `NRFUTIL_HOME` to a location that is outside of the mounted home directory.