### PR TITLE
app: Temporarily ignore maybe-unitialized compile error

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -7,4 +7,5 @@ tests:
       - thingy91x/nrf9151/ns
     platform_allow:
       - thingy91x/nrf9151/ns
+    extra_args: CMAKE_C_FLAGS='-Wno-maybe-uninitialized'
     tags: ci_build


### PR DESCRIPTION
Due to a bug in zephyr, compiler complains about an variable that may be used unitialized. This is fixed in zephyr commit
a6583f253eca3379f81b22481dcb30848e6d5665.

This patch temporarily disables the warning to get the build pass.