### PR TITLE
src: modules: battery: Cleanup

### DIFF
--- a/app/src/modules/battery/battery.c
+++ b/app/src/modules/battery/battery.c
@@ -8,9 +8,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/zbus/zbus.h>
 #include <zephyr/drivers/sensor/npm1300_charger.h>
-#include "nrf_fuel_gauge.h"
-#include <math.h>
 #include <zephyr/sys/util.h>
+#include <nrf_fuel_gauge.h>
+#include <math.h>
 
 #include "lp803448_model.h"
 #include "message_channel.h"
@@ -21,25 +21,26 @@ LOG_MODULE_REGISTER(battery, CONFIG_APP_BATTERY_LOG_LEVEL);
 /* Register subscriber */
 ZBUS_SUBSCRIBER_DEFINE(battery, CONFIG_APP_BATTERY_MESSAGE_QUEUE_SIZE);
 
-#define FG_BURST_COUNT 10
-#define FG_BURST_DELAY K_MSEC(100)
+/* nPM1300 register bitmasks */
+
+/* CHARGER.BCHGCHARGESTATUS.TRICKLECHARGE */
+#define NPM1300_CHG_STATUS_TC_MASK BIT(2)
+/* CHARGER.BCHGCHARGESTATUS.CONSTANTCURRENT */
+#define NPM1300_CHG_STATUS_CC_MASK BIT(3)
+/* CHARGER.BCHGCHARGESTATUS.CONSTANTVOLTAGE */
+#define NPM1300_CHG_STATUS_CV_MASK BIT(4)
 
 static const struct device *charger = DEVICE_DT_GET(DT_NODELABEL(npm1300_charger));
 static int64_t fg_ref_time;
-static float max_charge_current;
-static float term_charge_current;
-static float fg_burst_current_accumulated = 0;
-static float fg_burst_delta_accumulated = 0;
-static int fg_burst_index = 0;
 
-static int charger_read_sensors(float *voltage, float *current, float *temp)
+static int charger_read_sensors(float *voltage, float *current, float *temp, int32_t *chg_status)
 {
 	struct sensor_value value;
-	int ret;
+	int err;
 
-	ret = sensor_sample_fetch(charger);
-	if (ret < 0) {
-		return ret;
+	err = sensor_sample_fetch(charger);
+	if (err < 0) {
+		return err;
 	}
 
 	sensor_channel_get(charger, SENSOR_CHAN_GAUGE_VOLTAGE, &value);
@@ -51,66 +52,41 @@ static int charger_read_sensors(float *voltage, float *current, float *temp)
 	sensor_channel_get(charger, SENSOR_CHAN_GAUGE_AVG_CURRENT, &value);
 	*current = (float)value.val1 + ((float)value.val2 / 1000000);
 
+	sensor_channel_get(charger, (enum sensor_channel)SENSOR_CHAN_NPM1300_CHARGER_STATUS,
+			   &value);
+	*chg_status = value.val1;
+
 	return 0;
 }
 
 static void sample(void)
 {
-	/* Fuel gauge variables */
+	int err;
+	int chg_status;
+	bool charging;
 	float voltage;
 	float current;
 	float temp;
 	float state_of_charge;
 	float delta;
-	float time_to_empty;
-	float time_to_full;
-	static struct nrf_fuel_gauge_state_info fg_state;
-	int ret;
 
-	/* Update fuel gauge state */
-	ret = charger_read_sensors(&voltage, &current, &temp);
-	if (ret) {
-		LOG_ERR("Error: Could not read from charger device: %d", ret);
+	err = charger_read_sensors(&voltage, &current, &temp, &chg_status);
+	if (err) {
+		LOG_ERR("charger_read_sensors, error: %d", err);
 		SEND_FATAL_ERROR();
 		return;
 	}
 
 	delta = (float) k_uptime_delta(&fg_ref_time) / 1000.f;
-	fg_ref_time = k_uptime_get();
-	state_of_charge = nrf_fuel_gauge_process(voltage, current, temp, delta, &fg_state);
 
-	/* calculate TTE/TTF */
-	time_to_empty = nrf_fuel_gauge_tte_get();
-	time_to_full = nrf_fuel_gauge_ttf_get((bool)-max_charge_current, -term_charge_current);
+	charging = (chg_status & (NPM1300_CHG_STATUS_TC_MASK |
+				  NPM1300_CHG_STATUS_CC_MASK |
+				  NPM1300_CHG_STATUS_CV_MASK)) != 0;
 
-	fg_burst_current_accumulated += delta * current;
-	fg_burst_delta_accumulated += delta;
-
-	/* Repeat readings upto FG_BURST_COUNT measurement until we collect enough data points */
-	if (fg_burst_index++ < FG_BURST_COUNT) {
-		k_sleep(FG_BURST_DELAY);
-		sample();
-		return;
-	}
-
-	current = fg_burst_current_accumulated / fg_burst_delta_accumulated;
+	state_of_charge = nrf_fuel_gauge_process(voltage, current, temp, delta, NULL);
 
 	LOG_DBG("State of charge: %f", (double)roundf(state_of_charge));
-	LOG_DBG("Voltage: %f", (double)roundf(1000 * voltage));
-	LOG_DBG("Current: %f", (double)roundf(1000 * current));
-
-	if (isnormal(time_to_full)) {
-		LOG_DBG("Time to full: %f", (double)roundf(time_to_full));
-	}
-
-	if (isnormal(time_to_empty)) {
-		LOG_DBG("Time to empty: %f", (double)roundf(time_to_empty));
-	}
-
-	/* Reset burst variables */
-	fg_burst_index = 0;
-	fg_burst_current_accumulated = 0;
-	fg_burst_delta_accumulated = 0;
+	LOG_DBG("The battery is %s", charging ? "charging" : "not charging");
 
 	/* TODO: Encode in CBOR and publish to PAYLOAD channel
 
@@ -126,11 +102,13 @@ static void sample(void)
 
 static void battery_task(void)
 {
+	int err;
 	const struct zbus_channel *chan;
 	struct sensor_value value;
 	struct nrf_fuel_gauge_init_parameters parameters = {
 		.model = &battery_model
 	};
+	int32_t chg_status;
 
 	LOG_DBG("Battery module task started");
 
@@ -140,15 +118,20 @@ static void battery_task(void)
 		return;
 	}
 
-	int err = charger_read_sensors(&parameters.v0, &parameters.i0, &parameters.t0);
-
+	err = charger_read_sensors(&parameters.v0, &parameters.i0, &parameters.t0, &chg_status);
 	if (err < 0) {
 		LOG_ERR("charger_read_sensors, error: %d", err);
 		SEND_FATAL_ERROR();
 		return;
 	}
 
-	nrf_fuel_gauge_init(&parameters, NULL);
+	err = nrf_fuel_gauge_init(&parameters, NULL);
+	if (err) {
+		LOG_ERR("nrf_fuel_gauge_init, error: %d", err);
+		SEND_FATAL_ERROR();
+		return;
+	}
+
 	fg_ref_time = k_uptime_get();
 
 	err = sensor_channel_get(charger, SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT, &value);
@@ -157,9 +140,6 @@ static void battery_task(void)
 		SEND_FATAL_ERROR();
 		return;
 	}
-
-	max_charge_current = (float)value.val1 + ((float)value.val2 / 1000000);
-	term_charge_current = max_charge_current / 10.f;
 
 	while (!zbus_sub_wait(&battery, &chan, K_FOREVER)) {
 		if (&TRIGGER_CHAN == chan) {


### PR DESCRIPTION
Only include state of charge and charging state, initially we don't care about the rest.

For now, we are also removing the burst functionality. Running nrf_fuel_gauge_process() once per TRIGGER should hopefully be accurate enough.