### PR TITLE
zephyr: module.yml: remove unnecessary settings

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -9,12 +9,3 @@ build:
   # Path to the folder that contains the CMakeLists.txt file to be included by
   # Zephyr build system. The `.` is the root of this repository.
   cmake: .
-  settings:
-    # Additional roots for boards and DTS files. Zephyr will use the
-    # `<board_root>/boards` for additional boards. The `.` is the root of this
-    # repository.
-    board_root: .
-    # Zephyr will use the `<dts_root>/dts` for additional dts files and
-    # `<dts_root>/dts/bindings` for additional dts binding files. The `.` is
-    # the root of this repository.
-    dts_root: .


### PR DESCRIPTION
Remove board_root and dts_root from zephyr module. These are meant for large projects that defines new boards. This project only uses an existing board defined in sdk-nrf.

This fixes a build warning.