### PR TITLE
app: move timestamp to base time

### DIFF
--- a/app/src/modules/battery/bat_object.cddl
+++ b/app/src/modules/battery/bat_object.cddl
@@ -2,38 +2,34 @@
 ; depends on lwm2m_senml definitions
 
 state_of_charge = {
-	bn => "14202/0/",  ; Custom Environment information object
-	n => "0",          ; State of Charge ID
-	vi => int .size 1  ; State of Charge value
+	bn => "14202/0/",        ; Custom Environment information object
+	n => "0",                ; State of Charge ID
+	vi => int .size 1,       ; State of Charge value
+	bt => int .size 8        ; UNIX timestamp in milliseconds
 }
 voltage = {
-	n => "1",          ; Voltage Resource ID
-	vf => float,       ; Battery voltage in Volt.
+	n => "1",                ; Voltage Resource ID
+	vf => float,             ; Battery voltage in Volt.
 }
 current = {
-	n => "2",          ; Current Resource ID
-	vf => float,       ; Battery current in mA.
+	n => "2",                ; Current Resource ID
+	vf => float,             ; Battery current in mA.
 }
 temperature = {
-	n => "3",          ; Temperature Resource ID
-	vf => float,       ; Battery temperature in degrees Celsius.
+	n => "3",                ; Temperature Resource ID
+	vf => float,             ; Battery temperature in degrees Celsius.
 }
 time_to_full = {
-	n => "4",          ; Time to full Resource ID
-	vf => int .size 8, ; Time to full in seconds.
+	n => "4",                ; Time to full Resource ID
+	vf => int .size 8,       ; Time to full in seconds.
 }
 time_to_empty = {
-	n => "5",          ; Time to empty Resource ID
-	vf => int .size 8, ; Time to empty in seconds.
-}
-timestamp = {
-	n => "99",         ; Timestamp Resource ID
-	vi => int .size 8  ; UNIX timestamp in milliseconds
+	n => "5",                ; Time to empty Resource ID
+	vf => int .size 8,       ; Time to empty in seconds.
 }
 
 bat-object = [
 	state_of_charge,
 	voltage,
 	temperature,
-	timestamp
 ]

--- a/app/src/modules/battery/battery.c
+++ b/app/src/modules/battery/battery.c
@@ -99,10 +99,10 @@ static void sample(void)
 	LOG_DBG("State of charge: %f", (double)roundf(state_of_charge));
 	LOG_DBG("The battery is %s", charging ? "charging" : "not charging");
 
+	bat_object.state_of_charge_m.bt = system_time;
 	bat_object.state_of_charge_m.vi = (int32_t)(state_of_charge + 0.5f);
 	bat_object.voltage_m.vf = voltage;
 	bat_object.temperature_m.vf = temp;
-	bat_object.timestamp_m.vi = system_time;
 
 	err = cbor_encode_bat_object(payload.string, sizeof(payload.string),
 				     &bat_object, &payload.string_len);

--- a/app/src/modules/environmental/env_object.cddl
+++ b/app/src/modules/environmental/env_object.cddl
@@ -2,31 +2,27 @@
 ; depends on lwm2m_senml definitions
 
 temperature = {
-	bn => "14205/0/",  ; Custom Environment information object
-	n => "0",          ; Temperature Resource ID
-	vf => float,       ; temperature in degrees Celsius
+	bn => "14205/0/",        ; Custom Environment information object
+	n => "0",                ; Temperature Resource ID
+	vf => float,             ; temperature in degrees Celsius
+	bt => int .size 8        ; UNIX timestamp in milliseconds
 }
 humidity = {
-	n => "1",          ; Humidity Resource ID
-	vf => float,       ; Relative humidity in percent
+	n => "1",                ; Humidity Resource ID
+	vf => float,             ; Relative humidity in percent
 }
 pressure = {
-	n => "2",          ; Atmospheric pressure Resource ID
- 	vf => float,       ; Atmospheric pressure in pascals
+	n => "2",                ; Atmospheric pressure Resource ID
+ 	vf => float,             ; Atmospheric pressure in pascals
 }
 iaq = {
-	n => "10",         ; Air Quality Index Resource ID
-	vi => int .size 4  ; AQI value
-}
-timestamp = {
-	n => "99",         ; Timestamp Resource ID
-	vi => int .size 8  ; UNIX timestamp in milliseconds
+	n => "10",               ; Air Quality Index Resource ID
+	vi => int .size 4        ; AQI value
 }
 
 env-object = [
 	temperature,
 	humidity,
 	pressure,
-	iaq,
-	timestamp
+	iaq
 ]

--- a/app/src/modules/environmental/environmental.c
+++ b/app/src/modules/environmental/environmental.c
@@ -72,11 +72,11 @@ void env_callback(const struct zbus_channel *chan)
 			return;
 		}
 
+		env_obj.temperature_m.bt = system_time;
 		env_obj.temperature_m.vf = sensor_value_to_double(&temp);
 		env_obj.humidity_m.vf = sensor_value_to_double(&humidity);
 		env_obj.pressure_m.vf = sensor_value_to_double(&press);
 		env_obj.iaq_m.vi = iaq.val1;
-		env_obj.timestamp_m.vi = system_time;
 
 		ret = cbor_encode_env_object(payload.string, sizeof(payload.string),
 				       &env_obj, &payload.string_len);


### PR DESCRIPTION
This patch moves the timestamp of the
battery and environmental modules to base time.
This is for SenML compliance.