### PR TITLE
workflow: sonarcloud: fix coverage generation

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -42,15 +42,14 @@ jobs:
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v2
 
-      - name: Run build-wrapper
+      - name: Build and test
         working-directory: thingy91x-oob
         run: |
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} west twister -T . --build-only -C -v --inline-logs --integration
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} west twister -T . -C --coverage-platform=native_posix -v --inline-logs --integration
 
-      - name: Run native_posix tests
+      - name: Extract coverage into sonarqube xml format
         working-directory: thingy91x-oob
         run: |
-          west twister --test-only -v -i -C -T . -p native_posix
           gcovr twister-out -v --merge-mode-functions=separate --exclude=twister-out --sonarqube coverage.xml
 
       - name: Run sonar-scanner on main


### PR DESCRIPTION
twister was silently skipping coverage generation if the
coverage-platform parameter was not provided. This lead to no coverage
files being generated when invoking with the --integration option. This
is now fixed.

As a side, we do not need to separate the build and the test steps.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>