### PR TITLE
tests: simple_config: Move to native_sim

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build and test
         working-directory: thingy91x-oob
         run: |
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} west twister -T . -C --coverage-platform=native_posix -v --inline-logs --integration
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} west twister -T . -C --coverage-platform=native_sim -v --inline-logs --integration
 
       - name: Extract coverage into sonarqube xml format
         working-directory: thingy91x-oob

--- a/tests/lib/simple_config/testcase.yaml
+++ b/tests/lib/simple_config/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   net.lib.simple_config:
-    platform_allow: native_posix
+    platform_allow: native_sim
     integration_platforms:
-      - native_posix
+      - native_sim


### PR DESCRIPTION
This patch makes the test executable by twister on native_sim instead of native_posix. This is done to align with the other unit test in the repo and also it is a more modern platform for unit tests.