### PR TITLE
Revert: "app: Temporarily ignore maybe-unitialized compile error"

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -8,5 +8,4 @@ tests:
       - thingy91x/nrf9151/ns
     platform_allow:
       - thingy91x/nrf9151/ns
-    extra_args: CMAKE_C_FLAGS='-Wno-maybe-uninitialized'
     tags: ci_build


### PR DESCRIPTION
This reverts commit faf3262b7642334ded3a66b72f49c1b293fcccd0.

The warning is now fixed in the zephyr version included by latest ncs.