### PR TITLE
app: location: Use zbus subscriber instead of listener

### DIFF
--- a/app/src/modules/location/Kconfig.location
+++ b/app/src/modules/location/Kconfig.location
@@ -11,12 +11,18 @@ config APP_LOCATION_THREAD_STACK_SIZE
 	int "Thread stack size"
 	default 4096
 
+config APP_LOCATION_ZBUS_QUEUE_SIZE
+	int "Message queue size"
+	default 5
+	help
+	  ZBus subscriber message queue size.
+
 config APP_LOCATION_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout seconds"
 	default 120
 
-config APP_LOCATION_TRIGGER_TIMEOUT_SECONDS
-	int "Wait for trigger timeout seconds"
+config APP_LOCATION_ZBUS_TIMEOUT_SECONDS
+	int "Wait for zbus timeout seconds"
 	default 60
 
 module = APP_LOCATION

--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -22,13 +22,10 @@
 LOG_MODULE_REGISTER(location_module, CONFIG_APP_LOCATION_LOG_LEVEL);
 
 BUILD_ASSERT(CONFIG_APP_LOCATION_WATCHDOG_TIMEOUT_SECONDS >
-			 CONFIG_APP_LOCATION_TRIGGER_TIMEOUT_SECONDS,
-			 "Watchdog timeout must be greater than trigger timeout");
+	     CONFIG_APP_LOCATION_ZBUS_TIMEOUT_SECONDS,
+	     "Watchdog timeout must be greater than trigger timeout");
 
-
-static K_SEM_DEFINE(location_lib_sem, 1, 1);
-static K_SEM_DEFINE(modem_init_sem, 0, 1);
-static K_SEM_DEFINE(trigger_sem, 0, 1);
+ZBUS_SUBSCRIBER_DEFINE(location, CONFIG_APP_LOCATION_ZBUS_QUEUE_SIZE);
 
 static void location_event_handler(const struct location_event_data *event_data);
 
@@ -42,14 +39,30 @@ static void task_wdt_callback(int channel_id, void *user_data)
 	SEND_FATAL_ERROR();
 }
 
+void trigger_location_update(void)
+{
+	int err;
+	struct location_config config = {0};
+
+	location_config_defaults_set(&config, 0, NULL);
+	config.mode = LOCATION_REQ_MODE_ALL;
+	err = location_request(&config);
+	if (err == -EBUSY) {
+		LOG_WRN("Location request already in progress");
+	} else if (err) {
+		LOG_ERR("Unable to send location request: %d", err);
+	}
+}
+
 void location_task(void)
 {
 	int err = 0;
-	struct location_config config = {0};
+	const struct zbus_channel *chan;
 	int task_wdt_id;
 	const uint32_t wdt_timeout_ms = (CONFIG_APP_LOCATION_WATCHDOG_TIMEOUT_SECONDS * MSEC_PER_SEC);
+	const k_timeout_t zbus_timeout = K_SECONDS(CONFIG_APP_LOCATION_ZBUS_TIMEOUT_SECONDS);
 
-	k_sem_take(&modem_init_sem, K_FOREVER);
+	LOG_DBG("Location module task started");
 
 	task_wdt_id = task_wdt_add(wdt_timeout_ms, task_wdt_callback, (void *)k_current_get());
 	if (task_wdt_id < 0) {
@@ -59,24 +72,24 @@ void location_task(void)
 	}
 
 	err = location_init(location_event_handler);
-	if (err)
-	{
+	if (err) {
 		LOG_ERR("Unable to init location library: %d", err);
+		SEND_FATAL_ERROR();
+		return;
 	}
+
 	LOG_DBG("location library initialized");
 
 #if defined(CONFIG_LOCATION_METHOD_GNSS)
 	err = lte_lc_func_mode_set(LTE_LC_FUNC_MODE_ACTIVATE_GNSS);
-	if (err)
-	{
+	if (err) {
 		LOG_ERR("Unable to init GNSS: %d", err);
 	} else {
 		LOG_DBG("GNSS initialized");
 	}
 #endif
 
-	while (true)
-	{
+	while (true) {
 		err = task_wdt_feed(task_wdt_id);
 		if (err) {
 			LOG_ERR("Failed to feed the watchdog: %d", err);
@@ -84,48 +97,25 @@ void location_task(void)
 			return;
 		}
 
-		err = k_sem_take(&trigger_sem, K_SECONDS(CONFIG_APP_LOCATION_TRIGGER_TIMEOUT_SECONDS));
+		err = zbus_sub_wait(&location, &chan, zbus_timeout);
 		if (err == -EAGAIN) {
-			// Continue so we can feed the watchdog and wait for semaphore again.
 			continue;
+		} else if (err) {
+			LOG_ERR("zbus_sub_wait, error: %d", err);
+			SEND_FATAL_ERROR();
+			return;
 		}
 
-		location_config_defaults_set(&config, 0, NULL);
-		config.mode = LOCATION_REQ_MODE_ALL;
-		err = location_request(&config);
-		if (err)
-		{
-			LOG_ERR("Unable to send location request: %d", err);
+		if (&TRIGGER_CHAN == chan) {
+			LOG_DBG("Trigger received");
+			trigger_location_update();
 		}
-		k_sem_take(&location_lib_sem, K_FOREVER);
 	}
 }
 
 K_THREAD_DEFINE(location_module_tid, CONFIG_APP_LOCATION_THREAD_STACK_SIZE,
 		location_task, NULL, NULL, NULL,
 		K_HIGHEST_APPLICATION_THREAD_PRIO, 0, 0);
-
-static void trigger_callback(const struct zbus_channel *chan)
-{
-	if (&TRIGGER_CHAN == chan)
-	{
-		LOG_DBG("Trigger received");
-		k_sem_give(&trigger_sem);
-	}
-	if (&CLOUD_CHAN == chan)
-	{
-		LOG_DBG("Cloud status received");
-		const enum cloud_status *status = zbus_chan_const_msg(chan);
-
-		if (*status == CLOUD_CONNECTED)
-		{
-			LOG_DBG("Cloud connected, initializing location");
-			k_sem_give(&modem_init_sem);
-		}
-	}
-}
-
-ZBUS_LISTENER_DEFINE(location, trigger_callback);
 
 #if defined(CONFIG_LOCATION_METHOD_GNSS)
 /* Take time from PVT data and apply it to system time. */
@@ -165,8 +155,7 @@ static void report_gnss_location(const struct nrf_modem_gnss_pvt_data_frame *pvt
 	};
 
 	err = nrf_cloud_coap_location_send(&gnss_pvt, true);
-	if (err)
-	{
+	if (err) {
 		LOG_ERR("Failed to send location data: %d", err);
 	}
 }
@@ -174,8 +163,7 @@ static void report_gnss_location(const struct nrf_modem_gnss_pvt_data_frame *pvt
 
 static void location_event_handler(const struct location_event_data *event_data)
 {
-	switch (event_data->id)
-	{
+	switch (event_data->id) {
 	case LOCATION_EVT_LOCATION:
 		LOG_DBG("Got location: lat: %f, lon: %f, acc: %f",
 			(double) event_data->location.latitude,
@@ -210,13 +198,5 @@ static void location_event_handler(const struct location_event_data *event_data)
 	default:
 		LOG_DBG("Getting location: Unknown event %d", event_data->id);
 		break;
-	}
-	if (event_data->id == LOCATION_EVT_LOCATION ||
-	    event_data->id == LOCATION_EVT_RESULT_UNKNOWN ||
-	    event_data->id == LOCATION_EVT_TIMEOUT ||
-	    event_data->id == LOCATION_EVT_ERROR)
-	{
-		/* request completed */
-		k_sem_give(&location_lib_sem);
 	}
 }


### PR DESCRIPTION
Updated the location module to use zbus subscribe instead of a listener for consistency and easier logic. Removed semaphores and modem lib connection handling. Connection handling might be needed unless the location lib doesn't handle this internally, but it should probably be dealt with using the Zephyr State Machine Framework.