### PR TITLE
modules: app: Don't throw assertion on decoding failure

### DIFF
--- a/app/src/modules/app/app.c
+++ b/app/src/modules/app/app.c
@@ -64,8 +64,7 @@ static void shadow_get(bool get_desired)
 
 	err = cbor_decode_app_object(buf_cbor, buf_cbor_len, &app_object, &not_used);
 	if (err) {
-		LOG_ERR("Failed to decode app object, error: %d", err);
-		SEND_FATAL_ERROR();
+		LOG_ERR("Ignoring incoming configuration change due to decoding error: %d", err);
 		return;
 	}
 


### PR DESCRIPTION
Don't throw assertion on decoding failure.
This is to safeguard against potential protocol changes that may break decoding. If this happens a firmware update is likely needed to resolve the issue.