### PR TITLE
app: Make app_object schema future proof

### DIFF
--- a/app/src/modules/app/app_object.cddl
+++ b/app/src/modules/app/app_object.cddl
@@ -1,8 +1,13 @@
 ; Define the basic structure of the JSON object
+
+; The 'any' type is used in this schema to allow forward compatibility.
+; They are inserted into maps that may contain additional fields in the future.
+; This prevents cbor decoding from failing in the field when the cloud side has new fields.
 app-object = {
     ? "nrfcloud_mqtt_topic_prefix": tstr,
     ? "pairing": pairing-type,
-    "lwm2m": lwm2m-map
+    "lwm2m": lwm2m-map,
+    * tstr => any
 }
 
 ; Define the pairing object with nested topics
@@ -10,32 +15,39 @@ pairing-type = {
     "state": tstr,
     "topics": {
         "d2c": tstr,
-        "c2d": tstr
-    }
+        "c2d": tstr,
+        * tstr => any
+    },
+    * any => any
 }
 
 lwm2m-map = {
   ? "14240:1.0": led,
-  ? "14301:1.0": config
+  ? "14301:1.0": config,
+  * tstr => any
 }
 
 led = {
-  "0": led_inner_object
+  "0": led_inner_object,
+  * tstr => any
 }
 
 led_inner_object = {
   "0": int .size 4,
   "1": int .size 4,
   "2": int .size 4,
-  "99": int .size 8
+  "99": int .size 8,
+  * tstr => any
 }
 
 config = {
-  "0": config_inner_object
+  "0": config_inner_object,
+  * tstr => any
 }
 
 config_inner_object = {
   "0": int .size 8,
   "1": bool,
-  "99": int .size 8
+  "99": int .size 8,
+  * tstr => any
 }


### PR DESCRIPTION
Extended the schema by adding 'any' type members so that the schema is future proof and the app can respond to any new additional fields that may be populated by the cloud side