### PR TITLE
workflow: Add make release workflow

### DIFF
--- a/.github/workflows/attach_release_assets.yml
+++ b/.github/workflows/attach_release_assets.yml
@@ -1,0 +1,32 @@
+# Workflow that attaches additional assets to github release.
+name: Attach Release Assets
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  trigger-build:
+    uses: ./.github/workflows/build.yml
+
+  trigger-dfu-check:
+    uses: ./.github/workflows/dfu_check.yml
+
+  trigger-target-test:
+    uses: ./.github/workflows/on_target.yml
+
+  attach-assets:
+    runs-on: ubuntu-22.04
+    # Only make a release if the above jobs are passing
+    needs: [trigger-build, trigger-dfu-check, trigger-target-test]
+    steps:
+        - name: Download artifact
+          uses: actions/download-artifact@v4
+          with:
+           name: firmware
+
+        - name: Deploy release to github
+          uses: softprops/action-gh-release@v1
+          with:
+            fail_on_unmatched_files: true
+            files: hello.nrfcloud.com-*.*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_call:
   push:
     branches:
       - main
@@ -33,6 +34,31 @@ jobs:
           pip install -r nrf/scripts/requirements-build.txt
 
       - name: Build firmware
-        working-directory: thingy91x-oob
+        working-directory: thingy91x-oob/app
         run: |
-          west twister -T app -v --inline-logs --integration
+          west build -b thingy91x/nrf9151/ns -p
+
+      - name: Set VERSION
+        shell: bash
+        run: |
+          if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
+            echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
+          fi
+
+
+      - name: Rename artifacts
+        working-directory: thingy91x-oob/app/build
+        run: |
+          cp merged.hex hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app.hex
+          cp app/zephyr/.config hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app.config
+          cp app/zephyr/zephyr.signed.bin hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app_update_signed.bin
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware
+          if-no-files-found: error
+          path: |
+            thingy91x-oob/app/build/hello.nrfcloud.com-*.*

--- a/.github/workflows/dfu_check.yml
+++ b/.github/workflows/dfu_check.yml
@@ -1,6 +1,7 @@
 name: DFU image compatibility check
 
 on:
+  workflow_call:
   push:
     branches:
       - main

--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -1,6 +1,7 @@
 name: On_target
 
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       run_test:
@@ -48,6 +49,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: oob-t91x-hex
+          if-no-files-found: error
           path: thingy91x-oob/build/merged.hex
 
   test:


### PR DESCRIPTION
When a release is created this new workflow calls the other build
and test workflows and uploads the tested artifacts into github
release.
The existing workflows were modified to make them callable from other
workflows.
Build workflow now uploads the artifacts so that they can be added to
the release. The build workflow uploads the hex, bin and the .config
file. The names of the files will have the sha if built from main and
the tag name if built from a tag.

The release will look like this with the assets (tested on private fork)

![image](https://github.com/hello-nrfcloud/firmware/assets/41895435/1532a521-0ca5-45e4-812f-ce9dd736ab27)

The workflow run will look similar to this.

![image](https://github.com/hello-nrfcloud/firmware/assets/41895435/6332ba3b-1db3-43ec-ae4e-f19dba34223c)

Fixes: https://github.com/hello-nrfcloud/firmware/issues/139 