### PR TITLE
workflow: on_target: Fix missing type in inputs

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -1,4 +1,4 @@
-name: On_target
+name: Target tests
 
 on:
   workflow_call:
@@ -8,10 +8,10 @@ on:
         description: 'Run test stage'
         required: false
         default: 'yes'
-        type: select
+        type: choice
         options:
-          - yes
-          - no
+          - 'yes'
+          - 'no'
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
In order to provide options for input, the type: choice must be specified. This is now fixed.