### PR TITLE
workflow: on_target: Reuse build workflow to build firmware

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -3,57 +3,14 @@ name: Target tests
 on:
   workflow_call:
   workflow_dispatch:
-    inputs:
-      run_test:
-        description: 'Run test stage'
-        required: false
-        default: 'yes'
-        type: choice
-        options:
-          - 'yes'
-          - 'no'
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
   build:
-    name: Build
-    runs-on: ubuntu-22.04
-    container: ghcr.io/zephyrproject-rtos/ci:v0.26.13
-    env:
-      CMAKE_PREFIX_PATH: /opt/toolchains
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          path: thingy91x-oob
-
-      - name: Initialize
-        working-directory: thingy91x-oob
-        run: |
-          west init -l .
-          west config manifest.group-filter +bsec
-          west config build.sysbuild True
-          west update -o=--depth=1 -n
-
-      - name: Install dependencies
-        run: |
-          pip install -r nrf/scripts/requirements-build.txt
-
-      - name: Build firmware
-        working-directory: thingy91x-oob
-        run: |
-          west build -b thingy91x/nrf9151/ns app -p
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: oob-t91x-hex
-          if-no-files-found: error
-          path: thingy91x-oob/build/merged.hex
+    uses: ./.github/workflows/build.yml
 
   test:
-    if: github.event.inputs.run_test == 'yes' || github.event.inputs.run_test == '' || github.event.inputs.run_test == null
     name: Test
     needs: build
     runs-on: self-hosted
@@ -72,15 +29,29 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: oob-t91x-hex
+          name: firmware
           path: thingy91x-oob/tests/on_target/artifacts
+
+      - name: Set version
+        shell: bash
+        run: |
+          if [[ "${{ startsWith(github.ref, 'refs/tags/') }}" == "true" ]]; then
+            echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
+          fi
 
       - name: Verify artifact path
         working-directory: thingy91x-oob
         run: |
           ls -l tests/on_target/artifacts
 
-      - name: Run tests
-        working-directory: thingy91x-oob
+      - name: Install dependencies
+        working-directory: thingy91x-oob/tests/on_target
         run: |
-          ./tests/on_target/run-tests.sh
+          pip install -r requirements.txt --break-system-packages
+
+      - name: Run tests
+        working-directory: thingy91x-oob/tests/on_target
+        run: |
+          pytest -s -v tests --firmware-hex artifacts/hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app.hex

--- a/tests/on_target/run-tests.sh
+++ b/tests/on_target/run-tests.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-TOP_DIR="tests/on_target"
-
-pip install -r $TOP_DIR/requirements.txt --break-system-packages
-
-pytest -v -s $TOP_DIR/tests/test.py

--- a/tests/on_target/tests/conftest.py
+++ b/tests/on_target/tests/conftest.py
@@ -41,6 +41,8 @@ def get_uarts():
 def t91x_board():
     all_uarts = get_uarts()
     logger.info(f"All uarts discovered: {all_uarts}")
+    if not all_uarts:
+        pytest.fail("No UARTs found")
     log_uart_string = all_uarts[0]
     logger.info(f"Log UART: {log_uart_string}")
 
@@ -51,3 +53,18 @@ def t91x_board():
 		)
 
     uart.stop()
+
+
+@pytest.fixture(scope="module")
+def hex_file(request):
+    return request.config.getoption("--firmware-hex")
+
+
+# Add support for input arguments
+def pytest_addoption(parser):
+    parser.addoption(
+        "--firmware-hex",
+        action="store",
+        default="artifacts/merged.hex",
+        help="Path to the firmware hex file",
+    )

--- a/tests/on_target/tests/test_uart_output.py
+++ b/tests/on_target/tests/test_uart_output.py
@@ -15,11 +15,9 @@ logger = get_logger()
 
 TEST_TIMEOUT = 1 * 60
 
-TOP_DIR = os.getenv("TOP_DIR", "tests/on_target")
-HEX_FILE = os.path.abspath(os.path.join(TOP_DIR, "artifacts/merged.hex"))
 
-def test_program_board_and_check_uart(t91x_board):
-    flash_device(HEX_FILE)
+def test_program_board_and_check_uart(t91x_board, hex_file):
+    flash_device(os.path.abspath(hex_file))
 
     expected_lines = ["Network connectivity established", "Connected to Cloud"]
 


### PR DESCRIPTION
Previously the on_target workflow was re-doing the steps done by the build workflow. But since now the build workflow uploads the built firmware as artifacts, we now have the possibility to re-use it. The on_target workflow now calls the build worfklow and downloads its artifaacts to perform the tests.

The test fraemwork code was modified to accept new input argument firmware-hex that points to the hex file to test.