### PR TITLE
app: Remove debug configs and reduced heap size

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -13,8 +13,8 @@ CONFIG_PWM=y
 # Extended AT host/monitor stack/heap sizes since some nrf_cloud credentials are longer than 1024 bytes.
 CONFIG_AT_MONITOR_HEAP_SIZE=2048
 CONFIG_AT_HOST_STACK_SIZE=2048
-# Extended memory heap size needed both for PGPS and for encoding JSON-based nRF Cloud Device Messages.
-CONFIG_HEAP_MEM_POOL_SIZE=50000
+# Wifi scan requires extended heap size
+CONFIG_HEAP_MEM_POOL_SIZE=40000
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 
 # Enable Networking and Connection Manager.
@@ -183,12 +183,10 @@ CONFIG_NET_MGMT_EVENT_STACK_SIZE=2048
 CONFIG_NET_IF_MAX_IPV6_COUNT=2
 CONFIG_NET_IF_MAX_IPV4_COUNT=2
 
-# debug stuff
+# For debugging purposes
 CONFIG_LOG_MODE_IMMEDIATE=y
 CONFIG_RESET_ON_FATAL_ERROR=n
 CONFIG_THREAD_NAME=y
-CONFIG_DEBUG=y
-CONFIG_TFM_CMAKE_BUILD_TYPE_MINSIZEREL=y
 
 # Extra Logging
 CONFIG_APP_FOTA_LOG_LEVEL_DBG=y
@@ -208,6 +206,3 @@ CONFIG_NPM1300_CHARGER=y
 # Task Watchdog
 CONFIG_TASK_WDT=y
 CONFIG_TASK_WDT_CHANNELS=6
-
-# Optimize for space
-CONFIG_SIZE_OPTIMIZATIONS=y


### PR DESCRIPTION
Removed CONFIG_DEBUG from application. This also removes
the need for having to set the enable size optimizations separately.

