### PR TITLE
modules: app: Convert to MSG subscriber

### DIFF
--- a/app/src/modules/app/Kconfig.app
+++ b/app/src/modules/app/Kconfig.app
@@ -8,12 +8,6 @@ config APP_MODULE_THREAD_STACK_SIZE
 	int "Thread stack size"
 	default 8192
 
-config APP_MODULE_MESSAGE_QUEUE_SIZE
-	int "Message queue size"
-	default 5
-	help
-	  ZBus subscriber message queue size.
-
 config APP_MODULE_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout seconds"
 	default 120


### PR DESCRIPTION
Convert to MSG subscriber to ensure that the app module is able to receive messages from other modules with guaranteed delivery.

Fixes issue where the trigger module would send a POLL and DATA SAMPLE trigger at the same time, causing the app module to miss the POLL due to the payload being overwritten.