### PR TITLE
app: Add TIME_AVAILABLE event

### DIFF
--- a/app/src/common/message_channel.c
+++ b/app/src/common/message_channel.c
@@ -73,3 +73,11 @@ ZBUS_CHAN_DEFINE(BUTTON_CHAN,
 		 ZBUS_OBSERVERS(trigger),
 		 ZBUS_MSG_INIT(0)
 );
+
+ZBUS_CHAN_DEFINE(TIME_CHAN,
+		 enum time_status,
+		 NULL,
+		 NULL,
+		 ZBUS_OBSERVERS(battery, environmental),
+		 ZBUS_MSG_INIT(0)
+);

--- a/app/src/common/message_channel.h
+++ b/app/src/common/message_channel.h
@@ -48,6 +48,10 @@ enum trigger_type {
 	TRIGGER_DATA_SAMPLE,
 };
 
+enum time_status {
+	TIME_AVAILABLE = 0x1,
+};
+
 struct configuration {
 	bool led_present;
 	int led_red;
@@ -59,15 +63,16 @@ struct configuration {
 };
 
 ZBUS_CHAN_DECLARE(
-	TRIGGER_CHAN,
-	PAYLOAD_CHAN,
-	NETWORK_CHAN,
-	FATAL_ERROR_CHAN,
-	LED_CHAN,
+	BUTTON_CHAN,
 	CLOUD_CHAN,
-	FOTA_ONGOING_CHAN,
 	CONFIG_CHAN,
-	BUTTON_CHAN
+	FATAL_ERROR_CHAN,
+	FOTA_ONGOING_CHAN,
+	LED_CHAN,
+	NETWORK_CHAN,
+	PAYLOAD_CHAN,
+	TIME_CHAN,
+	TRIGGER_CHAN
 );
 
 #ifdef __cplusplus

--- a/tests/module/environmental/src/main.c
+++ b/tests/module/environmental/src/main.c
@@ -60,7 +60,7 @@ ZBUS_SUBSCRIBER_DEFINE(location, 1);
 ZBUS_SUBSCRIBER_DEFINE(app, 1);
 ZBUS_SUBSCRIBER_DEFINE(fota, 1);
 ZBUS_SUBSCRIBER_DEFINE(led, 1);
-ZBUS_SUBSCRIBER_DEFINE(battery, 1);
+ZBUS_SUBSCRIBER_DEFINE(battery, 2);
 
 /* When changing the format, print the new payload to the console and update the test cases.
  * Don't forget to paste the bytes into a decoder and check if the values are correct.
@@ -116,9 +116,14 @@ void test_only_timestamp(void)
 {
 	enum trigger_type trigger_type = TRIGGER_DATA_SAMPLE;
 	int err;
+	enum time_status time_status = TIME_AVAILABLE;
 
 	date_time_uptime_to_unix_time_ms_fake.custom_fake =
 		date_time_uptime_to_unix_time_ms_custom_fake;
+
+	err = zbus_chan_pub(&TIME_CHAN, &time_status, K_SECONDS(1));
+	TEST_ASSERT_EQUAL(0, err);
+	k_sleep(K_MSEC(100));
 
 	/* send trigger */
 	err = zbus_chan_pub(&TRIGGER_CHAN, &trigger_type, K_SECONDS(1));

--- a/tests/module/transport/src/transport_module_test.c
+++ b/tests/module/transport/src/transport_module_test.c
@@ -11,7 +11,6 @@
 
 DEFINE_FFF_GLOBALS;
 
-FAKE_VALUE_FUNC(int, date_time_uptime_to_unix_time_ms, int64_t *);
 FAKE_VALUE_FUNC(int, task_wdt_feed, int);
 FAKE_VALUE_FUNC(int, task_wdt_add, uint32_t, task_wdt_callback_t, void *);
 FAKE_VALUE_FUNC(int, nrf_cloud_client_id_get, char *, size_t);
@@ -20,16 +19,12 @@ FAKE_VALUE_FUNC(int, nrf_cloud_coap_connect, const char * const);
 FAKE_VALUE_FUNC(int, nrf_cloud_coap_disconnect);
 FAKE_VALUE_FUNC(int, nrf_cloud_coap_shadow_device_status_update);
 FAKE_VALUE_FUNC(int, nrf_cloud_coap_bytes_send, uint8_t *, size_t, bool);
-FAKE_VALUE_FUNC(int, date_time_register_handler, void *);
 
 static K_SEM_DEFINE(cloud_disconnected, 0, 1);
 static K_SEM_DEFINE(cloud_connected_ready, 0, 1);
 static K_SEM_DEFINE(cloud_connected_paused, 0, 1);
 static K_SEM_DEFINE(data_sent, 0, 1);
 static K_SEM_DEFINE(fatal_error_received, 0, 1);
-
-/* Needed to let the module complete initialization */
-extern struct k_sem date_time_ready_sem;
 
 static void dummy_cb(const struct zbus_channel *chan)
 {
@@ -77,7 +72,6 @@ void setUp(void)
 	/* Reset fakes */
 	RESET_FAKE(task_wdt_feed);
 	RESET_FAKE(task_wdt_add);
-	RESET_FAKE(date_time_uptime_to_unix_time_ms);
 
 	/* Clear all channels */
 	zbus_sub_wait(&location, &chan, K_NO_WAIT);
@@ -93,8 +87,6 @@ void setUp(void)
 void test_initial_transition_to_disconnected(void)
 {
 	int err;
-
-	k_sem_give(&date_time_ready_sem);
 
 	err = k_sem_take(&cloud_disconnected, K_SECONDS(1));
 	TEST_ASSERT_EQUAL(0, err);


### PR DESCRIPTION
The battery and environment modules use date_time library to timestamp sampled data.
These modules will now wait until time is available before sampling and attempting to timestamp data.
The tas to send the TIME_AVAILABLE event is taken by the app module.