### PR TITLE
tests: environmental: Remove trigger_callback function

### DIFF
--- a/tests/module/environmental/src/main.c
+++ b/tests/module/environmental/src/main.c
@@ -51,10 +51,9 @@ void compare_payloads(const struct payload *expected, const struct payload *actu
 	}
 }
 
-void trigger_callback(const struct zbus_channel *chan) {};
 
 ZBUS_LISTENER_DEFINE(transport, transport_callback);
-ZBUS_LISTENER_DEFINE(trigger, trigger_callback);
+ZBUS_LISTENER_DEFINE(trigger, NULL);
 
 /* define unused subscribers */
 ZBUS_SUBSCRIBER_DEFINE(location, 1);


### PR DESCRIPTION
This function is not needed because we do not need to get call backs in the test for the trigger channel.