### PR TITLE
workflow: sonarcloud: Make it trigger for changes to other files

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - '**/*.c'
       - '**/*.h'
+      - west.yml
+      - '**/CMakelists.txt'
+      - '**/Kconfig*'
+      - '**/prj.conf'
 jobs:
   build:
     name: Build and analyze


### PR DESCRIPTION
Make sonarcloud workflow trigger for PRs that change west.yml, CMakelists.txt and Kconfig files. This is because they all influence how the exectable is built and the compilation database.