### PR TITLE
workflow: on_target: Make the workflow run on push to main

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Make Target Tests run on every push to main. This is done to ensure that all commits on main are target tested so that when we make a release we know that we make it from a green commit.