### PR TITLE
workflow: dfu_check: Make it run only on relevant changes

### DIFF
--- a/.github/workflows/dfu_check.yml
+++ b/.github/workflows/dfu_check.yml
@@ -6,6 +6,13 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - '**/*.c'
+      - '**/*.h'
+      - west.yml
+      - '**/CMakelists.txt'
+      - '**/Kconfig*'
+      - '**/prj.conf'
 
 jobs:
   build:


### PR DESCRIPTION
Make the DFU image compatibility check run only for changes to certain files that may affect the image compatibility. On main, it will continue to run on all changes.