### PR TITLE
modules: network: Enable modem events

### DIFF
--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -247,6 +247,16 @@ static void network_task(void)
 		return;
 	}
 
+	if (IS_ENABLED(CONFIG_LTE_LINK_CONTROL)) {
+		/* Subscribe to modem events */
+		err = lte_lc_modem_events_enable();
+		if (err) {
+			LOG_ERR("lte_lc_modem_events_enable, error: %d", err);
+			SEND_FATAL_ERROR();
+			return;
+		}
+	}
+
 	/* Resend connection status if the sample is built for Native Posix.
 	 * This is necessary because the network interface is automatically brought up
 	 * at SYS_INIT() before main() is called.


### PR DESCRIPTION
Enable modem events to get warning about modem reset loop.