### PR TITLE
Add RSRP reporting to cloud

### DIFF
--- a/app/src/modules/network/conn_info.cddl
+++ b/app/src/modules/network/conn_info.cddl
@@ -1,13 +1,24 @@
 ; CDDL schema to encode the object defined in https://github.com/hello-nrfcloud/proto-map/blob/saga/lwm2m/14203.xml
 ; depends on lwm2m_senml definitions
 
-energy-estimate = {
-	bn => "14203/0/",                    ; Connection Information object
-	n => "11",                           ; Energy Estimate resource ID
-	vi => 5..9,                          ; Energy Estimate
-	bt => 1700000000...3000000000        ; UNIX timestamp in seconds
+base-attributes = {
+	bn => "14203/0/",                   ; Connection Information object
+	bt => 1700000000...3000000000       ; UNIX timestamp in seconds
 }
 
+rsrp = {
+	n => "2",                           ; RSRP resource ID
+	vi => -157..-44,                    ; RSRP (in dBm)
+}
+
+energy-estimate = {
+	n => "11",                          ; Energy Estimate resource ID
+	vi => 5..9,                         ; Energy Estimate
+}
+
+
 conn-info-object = [
+	base-attributes,
+	rsrp,
 	energy-estimate
 ]


### PR DESCRIPTION
RSRP will now be reported along with energy estimate.
CDDL schema updated and made clearer to support this.

Tested by verifying the the RSRP in the Connection Info lwm2m object pane
![image](https://github.com/hello-nrfcloud/firmware/assets/41895435/8fe98b12-04fc-4b83-9c85-293afe1ed632)
Verified that there are no decoding errors in the lwm2m objects reported to cloud. 
Unit tests updated.

Fixes https://github.com/hello-nrfcloud/firmware/issues/105 