### PR TITLE
Revert "modules: transport: Fix print statement"

### DIFF
--- a/app/src/modules/transport/transport.c
+++ b/app/src/modules/transport/transport.c
@@ -389,7 +389,7 @@ static void state_connected_ready_run(void *o)
 		int err;
 		struct payload *payload = (struct payload *)state_object->msg;
 
-		LOG_DBG("Sending payload to cloud: %s, len: %d",
+		LOG_DBG("Sending payload to cloud: %p, len: %d",
 			payload->string, payload->string_len);
 
 		err = nrf_cloud_coap_bytes_send(payload->string, payload->string_len, false);


### PR DESCRIPTION
The print does not print useful information as it merely prints the readable bytes of the binary encoded payload. Printing the pointer instead may be slightly more useful for debugging purposes.

This reverts commit 4f9033734220784ab62e115f38930760684a9de7.