### PR TITLE
treewide: Use same lowest application thread prio for all threads

### DIFF
--- a/app/src/modules/app/app.c
+++ b/app/src/modules/app/app.c
@@ -206,7 +206,7 @@ static void app_task(void)
 
 K_THREAD_DEFINE(app_task_id,
 		CONFIG_APP_MODULE_THREAD_STACK_SIZE,
-		app_task, NULL, NULL, NULL, 3, 0, 0);
+		app_task, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
 
 static int watchdog_init(void)
 {

--- a/app/src/modules/battery/battery.c
+++ b/app/src/modules/battery/battery.c
@@ -320,4 +320,4 @@ static void battery_task(void)
 
 K_THREAD_DEFINE(battery_task_id,
 		CONFIG_APP_BATTERY_THREAD_STACK_SIZE,
-		battery_task, NULL, NULL, NULL, 3, 0, 0);
+		battery_task, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);

--- a/app/src/modules/environmental/environmental.c
+++ b/app/src/modules/environmental/environmental.c
@@ -240,4 +240,4 @@ static void environmental_task(void)
 
 K_THREAD_DEFINE(environmental_task_id,
 		CONFIG_APP_ENVIRONMENTAL_THREAD_STACK_SIZE,
-		environmental_task, NULL, NULL, NULL, 3, 0, 0);
+		environmental_task, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);

--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -210,7 +210,7 @@ void location_task(void)
 
 K_THREAD_DEFINE(location_module_tid, CONFIG_APP_LOCATION_THREAD_STACK_SIZE,
 		location_task, NULL, NULL, NULL,
-		K_HIGHEST_APPLICATION_THREAD_PRIO, 0, 0);
+		K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);
 
 /* Take time from PVT data and apply it to system time. */
 static void apply_gnss_time(const struct nrf_modem_gnss_pvt_data_frame *pvt_data)

--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -308,4 +308,4 @@ static void network_task(void)
 
 K_THREAD_DEFINE(network_task_id,
 		CONFIG_APP_NETWORK_THREAD_STACK_SIZE,
-		network_task, NULL, NULL, NULL, 3, 0, 0);
+		network_task, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);

--- a/app/src/modules/shell/shell.c
+++ b/app/src/modules/shell/shell.c
@@ -109,7 +109,6 @@ static int cmd_zbus_ping(const struct shell *sh, size_t argc,
 {
 	int err;
 	enum zbus_test_type test_type;
-	
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
@@ -253,4 +252,4 @@ SHELL_CMD_REGISTER(uart, &sub_uart, "UART shell", NULL);
 
 K_THREAD_DEFINE(shell_task_id,
 		CONFIG_APP_SHELL_THREAD_STACK_SIZE,
-		shell_task, NULL, NULL, NULL, 3, 0, 0);
+		shell_task, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);

--- a/app/src/modules/transport/transport.c
+++ b/app/src/modules/transport/transport.c
@@ -490,4 +490,4 @@ static void transport_task(void)
 
 K_THREAD_DEFINE(transport_task_id,
 		CONFIG_APP_TRANSPORT_THREAD_STACK_SIZE,
-		transport_task, NULL, NULL, NULL, 3, 0, 0);
+		transport_task, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, 0);


### PR DESCRIPTION
Use the same lowest application thread priority while creating all threads in the application.