### PR TITLE
modules: trigger: Remove stopping of poll duration timer

### DIFF
--- a/app/src/modules/trigger/trigger.c
+++ b/app/src/modules/trigger/trigger.c
@@ -368,7 +368,6 @@ static void frequent_poll_exit(void *o)
 
 	k_work_cancel_delayable(&trigger_poll_work);
 	k_work_cancel_delayable(&trigger_data_sample_work);
-	k_timer_stop(&frequent_poll_duration_timer);
 }
 
 /* STATE_NORMAL */


### PR DESCRIPTION
Remove stopping of poll duration timer:

We need to keep this timer running to ensure that we go into the normal state where data sample and poll triggers are sent less frequently after 10 minutes.

Without this patch we will persist in the frequent poll state forever.