### PR TITLE
ci: nrf53 bootloader: stay in recovery on fail

### DIFF
--- a/scripts/connectivity_bridge.patch
+++ b/scripts/connectivity_bridge.patch
@@ -79,3 +79,13 @@ index 55367dc403..97653fbc26 100644
  
  error:
  	/* default reply: command failed */
+diff --git a/applications/connectivity_bridge/sysbuild/mcuboot/boards/thingy91x_nrf5340_cpuapp.conf b/applications/connectivity_bridge/sysbuild/mcuboot/boards/thingy91x_nrf5340_cpuapp.conf
+index 37c7e95b15..8bbd4ddf94 100644
+--- a/applications/connectivity_bridge/sysbuild/mcuboot/boards/thingy91x_nrf5340_cpuapp.conf
++++ b/applications/connectivity_bridge/sysbuild/mcuboot/boards/thingy91x_nrf5340_cpuapp.conf
+@@ -58,3 +58,5 @@ CONFIG_BOOT_SERIAL_IMG_GRP_IMAGE_STATE=y
+ 
+ # Skip checks on the secondary image to make it possible to update MCUBoot on S1/S0
+ CONFIG_MCUBOOT_VERIFY_IMG_ADDRESS=n
++
++CONFIG_BOOT_SERIAL_NO_APPLICATION=y


### PR DESCRIPTION
This patch configures the bootloader to stay in recovery mode if no valid application is found. This is needed for an internal process.