### PR TITLE
modules: fota: Limit polling for FOTA jobs

### DIFF
--- a/app/src/modules/fota/Kconfig.fota
+++ b/app/src/modules/fota/Kconfig.fota
@@ -33,6 +33,12 @@ config APP_FOTA_REBOOT_DELAY_SECONDS
 	  Delay in seconds before rebooting after a FOTA_STATUS_REBOOT_PENDING event has been
 	  sent.
 
+config APP_FOTA_POLL_INTERVAL_SECONDS
+	int "Min poll interval seconds"
+	default 60
+	help
+	  Minimum duration in between polling for FOTA updates.
+
 if APP_FOTA
 
 module = APP_FOTA


### PR DESCRIPTION
Limit polling for FOTA jobs to a minimum of 60 seconds. This is to reduce the power and data consumption of the device.

The values can be changed by setting the
CONFIG_APP_FOTA_POLL_INTERVAL_SECONDS option.