### PR TITLE
workflow: sonarcloud: Do not exclude tests from coverage

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Extract coverage into sonarqube xml format
         working-directory: thingy91x-oob
         run: |
-          gcovr twister-out -v --merge-mode-functions=separate --exclude='twister-out|tests|drivers' --sonarqube coverage.xml
+          gcovr twister-out -v --merge-mode-functions=separate --exclude='twister-out|drivers' --sonarqube coverage.xml
 
       - name: Run sonar-scanner on main
         working-directory: thingy91x-oob


### PR DESCRIPTION
Remove the exclusion of tests folder from code coverage reports. This lead to false reports about less coverage for newly added code.