### PR TITLE
modules: transport: Explicitly disconnect CoAP on network disconnect

### DIFF
--- a/app/src/modules/app/app.c
+++ b/app/src/modules/app/app.c
@@ -51,12 +51,19 @@ static void shadow_get(bool delta_only)
 		return;
 	} else if (err) {
 		LOG_ERR("Failed to request shadow delta: %d", err);
-		SEND_FATAL_ERROR();
 		return;
 	}
 
 	if (buf_cbor_len == 0) {
 		LOG_WRN("No shadow delta changes available");
+		return;
+	}
+
+	/* Workaroud: Sometimes nrf_cloud_coap_shadow_get() returns 0 even though obtaining
+	 * the shadow failed. Ignore the payload if the first 10 bytes are zero.
+	 */
+	if (!memcmp(buf_cbor, "\0\0\0\0\0\0\0\0\0\0", 10)) {
+		LOG_WRN("Returned buffer is empty, ignore");
 		return;
 	}
 

--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: 954143d37b4e4d65f89252e8fb347d923fa4c051
+      revision: pull/16808/head
       import: true


### PR DESCRIPTION
Explicitly disconnect CoAP on network disconnect:
 - Register listener that explicitly calls nrf_cloud_coap_disconnect() on lost LTE network.

   This is needed due to the likelyhood of the transport module thread being blocked performing a CoAP request when the network disconnects.

- Send reconnection event on the transport private channel when calls to the nrf_cloud_coap_bytes send fails. This is to detect when the socket has been closed so that the transport module can reconnect.

- Update manifest to include updates to the nrf cloud coap library needed for this change.