### PR TITLE
modules: network: Increase WDT to 30 seconds

### DIFF
--- a/app/src/modules/network/Kconfig.network
+++ b/app/src/modules/network/Kconfig.network
@@ -17,7 +17,7 @@ config APP_NETWORK_WATCHDOG_TIMEOUT_SECONDS
 
 config APP_NETWORK_EXEC_TIME_SECONDS_MAX
 	int "Maximum execution time seconds"
-	default 3
+	default 30
 	help
 	  Maximum time allowed for a single execution of the module's thread loop.
 


### PR DESCRIPTION
Under certain conditions sampling connection quality can take upwards to 20 seconds (observed).

To prevent a WD kicking in the WDT is now increased to 30 seconds. (Added some extra seconds just in case)