### PR TITLE
modules: app: Improve device shadow cloud errors

### DIFF
--- a/app/config/memfault_trace_reason_user_config.def
+++ b/app/config/memfault_trace_reason_user_config.def
@@ -2,4 +2,5 @@
  * Please refer to https://docs.memfault.com/docs/embedded/trace-events for more details.
  */
 
-MEMFAULT_TRACE_REASON_DEFINE(decode_error)
+MEMFAULT_TRACE_REASON_DEFINE(cbor_decode_app_object)
+MEMFAULT_TRACE_REASON_DEFINE(nrf_cloud_coap_shadow_get)

--- a/app/src/common/message_channel.h
+++ b/app/src/common/message_channel.h
@@ -94,7 +94,6 @@ enum location_status {
 enum error_type {
 	ERROR_FATAL = 0x1,
 	ERROR_IRRECOVERABLE,
-	ERROR_DECODE,
 };
 
 /** @brief Status sent from the FOTA module on the FOTA_STATUS_CHAN channel. */

--- a/app/src/modules/memfault/memfault.c
+++ b/app/src/modules/memfault/memfault.c
@@ -35,16 +35,7 @@ void callback(const struct zbus_channel *chan)
 			on_connected();
 		}
 	}
-
-	if (&ERROR_CHAN == chan) {
-		const enum error_type *type = zbus_chan_const_msg(chan);
-
-		if (*type == ERROR_DECODE) {
-			MEMFAULT_TRACE_EVENT(decode_error);
-		}
-	}
 }
 
 ZBUS_LISTENER_DEFINE(memfault, callback);
 ZBUS_CHAN_ADD_OBS(CLOUD_CHAN, memfault, 0);
-ZBUS_CHAN_ADD_OBS(ERROR_CHAN, memfault, 0);


### PR DESCRIPTION
In case the cloud side returns an error it should be handled as a recoverable error. Do not attempt to parse the response, but report the error and return code to Memfault if Memfault is enabled.

After discussion with @simensrostad, we decided to call the Memfault macro directly from the code, so Memfault correctly sees what line sent the error. Also changed from generic errors to more specific errors for each use case.

CIA-1289