### PR TITLE
modules: Smaller fixes

### DIFF
--- a/app/src/modules/transport/transport.c
+++ b/app/src/modules/transport/transport.c
@@ -346,8 +346,9 @@ static void state_connected_exit(void *o)
 		LOG_ERR("nrf_cloud_coap_disconnect, error: %d", err);
 		SEND_FATAL_ERROR();
 	}
-}
 
+	connect_work_cancel();
+}
 
 /* Handlers for STATE_CONNECTED_READY */
 

--- a/app/src/modules/trigger/trigger.c
+++ b/app/src/modules/trigger/trigger.c
@@ -410,8 +410,9 @@ static void normal_entry(void *o)
 	LOG_DBG("Sending FOTA poll triggers every %d seconds",
 		CONFIG_APP_TRIGGER_FOTA_POLL_INTERVAL_SEC);
 
-	k_work_reschedule(&trigger_work, K_NO_WAIT);
-	k_work_reschedule(&trigger_fota_poll_work, K_NO_WAIT);
+	k_work_reschedule(&trigger_work, K_SECONDS(user_object->update_interval_used_sec));
+	k_work_reschedule(&trigger_fota_poll_work,
+			  K_SECONDS(CONFIG_APP_TRIGGER_FOTA_POLL_INTERVAL_SEC));
 }
 
 static void normal_run(void *o)

--- a/tests/module/trigger/src/main.c
+++ b/tests/module/trigger/src/main.c
@@ -198,9 +198,6 @@ static void go_to_normal_state(void)
 	go_to_frequent_poll_state();
 	send_frequent_poll_duration_timer_expiry();
 	check_trigger_mode_event(TRIGGER_MODE_NORMAL);
-	check_trigger_event(TRIGGER_DATA_SAMPLE);
-	check_trigger_event(TRIGGER_POLL);
-	check_trigger_event(TRIGGER_FOTA_POLL);
 }
 
 void test_init_to_frequent_poll(void)
@@ -228,11 +225,14 @@ void test_frequent_poll_to_normal(void)
 
 	/* Then */
 	check_trigger_mode_event(TRIGGER_MODE_NORMAL);
-	/* Verify that one more trigger event was sent when entering normal mode. */
+	check_no_trigger_events(CONFIG_APP_TRIGGER_TIMEOUT_SECONDS - 10);
+
+	k_sleep(K_SECONDS(10));
+
 	check_trigger_event(TRIGGER_DATA_SAMPLE);
 	check_trigger_event(TRIGGER_POLL);
 	check_trigger_event(TRIGGER_FOTA_POLL);
-	check_no_trigger_events(FREQUENT_POLL_TRIGGER_INTERVAL_SEC * 10);
+
 	/* Cleanup */
 	send_cloud_disconnected();
 }
@@ -334,10 +334,15 @@ void test_frequent_poll_to_blocked_to_normal(void)
 
 	/* Then */
 	check_trigger_mode_event(TRIGGER_MODE_NORMAL);
+	check_no_trigger_events(CONFIG_APP_TRIGGER_TIMEOUT_SECONDS - 10);
+
+	k_sleep(K_SECONDS(10));
+
 	check_trigger_event(TRIGGER_DATA_SAMPLE);
 	check_trigger_event(TRIGGER_POLL);
 	check_trigger_event(TRIGGER_FOTA_POLL);
-	check_no_trigger_events(FREQUENT_POLL_TRIGGER_INTERVAL_SEC * 10);
+
+	check_no_trigger_events(CONFIG_APP_TRIGGER_TIMEOUT_SECONDS - 10);
 
 	/* Cleanup */
 	send_cloud_disconnected();


### PR DESCRIPTION
Cancel ongoing connection work on LTE disconnect.
There is no point of trying to reconnect if LTE is disconnected.

_________________________________________________________________

When entering normal mode, schedule triggers after the respective
timeouts, not immediately.

This fix prevents the trigger module from firing triggers every time
the GNSS is disabled in normal mode.
This issue occurs when a trigger is sent, and GNSS finishes sampling,
causing an endless loop of back-and-forth triggers instead of
returning to the expected interval.