### PR TITLE
west: update sdk-nrf version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: pull/16808/head
+      revision: 33ca63e6d64a1bdeb78824141fea68d915a8a45b
       import: true


### PR DESCRIPTION
The PR 16808 has been merged, so the reference to sdk-nrf can be updated to the latest main sha.

Fixes #212