### PR TITLE
manifest: Update sdk-nrf

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,5 +14,5 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: 33ca63e6d64a1bdeb78824141fea68d915a8a45b
+      revision: pull/16862/head
       import: true


### PR DESCRIPTION
Update sdk-nrf to pull in change that limits getting modem parameters to when the modem is not in offline mode.

The on target test currently fails quite often due to the modem being put in offline mode in between tests.
This in turn triggers a warning in the memfault lte integration layer that calls the modem info API that fail.