### PR TITLE
modules: location: Don't assert on location error

### DIFF
--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -249,7 +249,6 @@ static void location_event_handler(const struct location_event_data *event_data)
 		break;
 	case LOCATION_EVT_ERROR:
 		LOG_WRN("Getting location failed");
-		SEND_FATAL_ERROR();
 		break;
 	default:
 		LOG_DBG("Getting location: Unknown event %d", event_data->id);


### PR DESCRIPTION
Don't assert on location error. This event is notified when the underlying transport library fails to send location to nRF cloud, which is common during poor network conditions.

This is acceptable and the device should recover. Ideally we would have an event reserved for fatal errors.