### PR TITLE
modules: location: Send LOCATION_SEARCH_DONE on error

### DIFF
--- a/app/src/modules/location/location.c
+++ b/app/src/modules/location/location.c
@@ -249,6 +249,7 @@ static void location_event_handler(const struct location_event_data *event_data)
 		break;
 	case LOCATION_EVT_ERROR:
 		LOG_WRN("Getting location failed");
+		status_send(LOCATION_SEARCH_DONE);
 		break;
 	default:
 		LOG_DBG("Getting location: Unknown event %d", event_data->id);


### PR DESCRIPTION
Send LOCATION_SEARCH_DONE event on LOCATION_SEARCH_DONE so that the trigger modules gets out of the blocked state on error condition and tries again during the next location update. This situation happens when the network connectivity was lost and then was restored again and the location module tries to fetch the location and fails due to coap issues.