### PR TITLE
workflow: on_target: Use fixed docker image version

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: self-hosted
     environment: production
     container:
-      image: ghcr.io/hello-nrfcloud/firmware:latest
+      image: ghcr.io/hello-nrfcloud/firmware:v2.0.0-preview31
       options: --privileged
       volumes:
         - /dev:/dev:rw


### PR DESCRIPTION
The current latest docker version v2.0.0-preview32 has issues with  nrfutil device version. This patch pins the docker image version to  the last known working docker image to unblock CI.