### PR TITLE
tests: on_target: Add wait before button press

### DIFF
--- a/tests/on_target/tests/test_uart_output.py
+++ b/tests/on_target/tests/test_uart_output.py
@@ -57,6 +57,8 @@ def test_program_board_and_check_uart(t91x_board, hex_file):
 
 
     t91x_board.uart.flush()
+    # Sleep for 5 seconds to allow any location update to complete before button press
+    time.sleep(5)
     # Simulate button press
     t91x_board.uart.write("zbus button_press\r\n")
 


### PR DESCRIPTION
The latest changes in the firmware makes the firmware remain in blocked state until location is obtained (not just until GNSS was active). So we need to add a delay before simulating a button press and expect the frequent_poll_run trace.