### PR TITLE
modules: trigger: Poll on button press when blocked

### DIFF
--- a/app/src/modules/trigger/trigger.c
+++ b/app/src/modules/trigger/trigger.c
@@ -311,6 +311,8 @@ static void blocked_run(void *o)
 			user_object->button_number);
 
 		frequent_poll_duration_timer_start(true);
+		trigger_send(TRIGGER_POLL, K_SECONDS(1));
+		trigger_send(TRIGGER_FOTA_POLL, K_SECONDS(1));
 
 	} else if (user_object->chan == &CONFIG_CHAN) {
 		LOG_DBG("Configuration received, refreshing poll duration timer");


### PR DESCRIPTION
Poll for cloud changes and FOTA in blocked state.
Previously we only restarted the frequent poll duration timer. This change allows users to get the latest cloud config / FOTA job right away without waiting for the next poll interval.