### PR TITLE
modules: trigger: Increase poll timer to 30 seconds

### DIFF
--- a/app/src/modules/trigger/trigger.c
+++ b/app/src/modules/trigger/trigger.c
@@ -30,7 +30,7 @@ ZBUS_CHAN_ADD_OBS(LOCATION_CHAN, trigger, 0);
 /* Data sample trigger interval in the frequent poll state */
 #define FREQUENT_POLL_TRIGGER_INTERVAL_SEC 60
 /* Shadow poll trigger interval in the frequent poll state */
-#define FREQUENT_POLL_SHADOW_POLL_TRIGGER_INTERVAL_SEC 20
+#define FREQUENT_POLL_SHADOW_POLL_TRIGGER_INTERVAL_SEC 30
 
 /* Forward declarations */
 static void trigger_work_fn(struct k_work *work);


### PR DESCRIPTION
To circumvent a cloud issue currently being looked into we need to increase the frequent poll timer to 30 seconds to prevent the TLS session from being lost cloud side.