### PR TITLE
tests: on_target: split uart and fota steps

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -59,10 +59,17 @@ jobs:
         run: |
           pip install -r requirements.txt --break-system-packages
 
-      - name: Run UART and FOTA tests
+      - name: Run UART tests
         working-directory: thingy91x-oob/tests/on_target
         run: |
-          pytest -s -v -m dut1 tests --firmware-hex artifacts/hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app.hex
+          pytest -s -v -m "dut1 and uart" tests --firmware-hex artifacts/hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app.hex
+        env:
+          SEGGER: ${{ secrets.SEGGER_DUT_1 }}
+
+      - name: Run FOTA tests
+        working-directory: thingy91x-oob/tests/on_target
+        run: |
+          pytest -s -v -m "dut1 and fota" tests --firmware-hex artifacts/hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app.hex
         env:
           SEGGER: ${{ secrets.SEGGER_DUT_1 }}
           IMEI: ${{ secrets.IMEI_DUT_1 }}

--- a/tests/on_target/README.md
+++ b/tests/on_target/README.md
@@ -22,12 +22,44 @@ nrfutil -V
 nrfutil device list
 ```
 
-### Run test
+### Install requirements
 ```shell
 cd thingy91x-oob/tests/on_target
 pip install -r requirements.txt --break-system-packages
+```
+
+### Run UART tests
+
+Precondition: thingy91x with segger fw on 53
+
+```shell
 export SEGGER=<your_segger>
-pytest -s -v -m dut1 tests --firmware-hex artifacts/merged.hex
+pytest -s -v -m "dut1 and uart" tests --firmware-hex artifacts/merged.hex
+```
+
+### Run FOTA tests
+
+Precondition: thingy91x with segger fw on 53
+
+```shell
+export SEGGER=<your_segger>
+export IMEI=<your_imei>
+export FINGERPRINT=<your_fingerprint>
+pytest -s -v -m "dut1 and fota" tests --firmware-hex artifacts/merged.hex
+```
+
+### Run DFU tests
+
+Precondition: thingy91x with external debugger attached
+
+IMPORTANT: switch must be on nrf53 otherwise device will be bricked.
+
+Set all this bunch of env variables appropriately (see worflow for details):
+SEGGER_NRF53, SEGGER_NRF91, UART_ID, NRF53_HEX_FILE, NRF53_APP_UPDATE_ZIP,
+NRF53_BL_UPDATE_ZIP, NRF91_HEX_FILE, NRF91_APP_UPDATE_ZIP, NRF91_BL_UPDATE_ZIP
+
+```
+pytest -s -v -m dut2 tests
 ```
 
 ## Test docker image version control

--- a/tests/on_target/tests/pytest.ini
+++ b/tests/on_target/tests/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 markers =
-    dut1
-    dut2
+    dut1: device used for uart and fota tests
+    dut2: device used for dfu tests
+    uart: uart tests
+    fota: fota tests

--- a/tests/on_target/tests/test_fota.py
+++ b/tests/on_target/tests/test_fota.py
@@ -21,6 +21,7 @@ WAIT_FOR_FOTA_AVAILABLE = 60
 APP_FOTA_TIMEOUT = 60 * 10
 
 @pytest.mark.dut1
+@pytest.mark.fota
 def test_app_fota(t91x_board, hex_file):
     flash_device(os.path.abspath(hex_file))
     time.sleep(5)

--- a/tests/on_target/tests/test_uart_output.py
+++ b/tests/on_target/tests/test_uart_output.py
@@ -15,7 +15,8 @@ from utils.logger import get_logger
 logger = get_logger()
 
 @pytest.mark.dut1
-def test_program_board_and_check_uart(t91x_board, hex_file):
+@pytest.mark.uart
+def test_uart_output(t91x_board, hex_file):
     flash_device(os.path.abspath(hex_file))
     time.sleep(5)
     t91x_board.uart.xfactoryreset()


### PR DESCRIPTION
Splitting fota and uart tests in two steps in the workflow.