### PR TITLE
modules: network: Ignore invalid RSRP values

### DIFF
--- a/app/src/modules/network/conn_info.cddl
+++ b/app/src/modules/network/conn_info.cddl
@@ -8,7 +8,7 @@ base-attributes = {
 
 rsrp = {
 	n => "2",                           ; RSRP resource ID
-	vi => -157..-43,                    ; RSRP (in dBm)
+	? vi => -157..-43,                  ; RSRP (in dBm)
 }
 
 energy-estimate = {

--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -180,11 +180,18 @@ static void sample_network_quality(void)
 
 	conn_info_obj.base_attributes_m.bt = (int32_t)(system_time / 1000);
 	conn_info_obj.energy_estimate_m.vi = conn_eval_params.energy_estimate;
-	conn_info_obj.rsrp_m.vi = RSRP_IDX_TO_DBM(conn_eval_params.rsrp);
+
+	if (conn_eval_params.rsrp == LTE_LC_CELL_RSRP_INVALID) {
+		LOG_WRN("RSRP value is invalid, ignoring");
+	} else {
+		conn_info_obj.rsrp_m.vi_present = true;
+		conn_info_obj.rsrp_m.vi.vi = RSRP_IDX_TO_DBM(conn_eval_params.rsrp);
+
+		LOG_DBG("RSRP: %d dBm", conn_info_obj.rsrp_m.vi.vi);
+	}
 
 	LOG_DBG("System Time: %d", conn_info_obj.base_attributes_m.bt);
 	LOG_DBG("Energy Estimate: %d", conn_info_obj.energy_estimate_m.vi);
-	LOG_DBG("RSRP: %d dBm", conn_info_obj.rsrp_m.vi);
 
 	ret = cbor_encode_conn_info_object(payload.buffer, sizeof(payload.buffer),
 					   &conn_info_obj, &payload.buffer_len);


### PR DESCRIPTION
With the previous CDDL boundaries for RSRP, encoding would fail if the returned RSRP was not obtained (invalid).

Ignore invalid RSRP values:
 - Make RSRP optional in CDDL schema
 - Update tests