### PR TITLE
Docker: Fix new URL for go language webpage

### DIFF
--- a/tests/on_target/Dockerfile
+++ b/tests/on_target/Dockerfile
@@ -37,7 +37,7 @@ EOT
 
 # Install Go
 RUN <<EOT
-    wget --max-redirect=0  https://golang.org/dl/go1.20.5.linux-amd64.tar.gz
+    wget --max-redirect=0  https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
     tar -C /usr/local -xzf go1.20.5.linux-amd64.tar.gz
     rm go1.20.5.linux-amd64.tar.gz
 EOT


### PR DESCRIPTION
golang.org is now go.dev. Hence the DockerFile must be changed to fetch go from the new server.