### PR TITLE
modules: Unify timeout for `zbus_chan_pub`

### DIFF
--- a/app/src/modules/battery/battery.c
+++ b/app/src/modules/battery/battery.c
@@ -251,7 +251,7 @@ static void sample(int64_t *ref_time)
 		return;
 	}
 
-	err = zbus_chan_pub(&PAYLOAD_CHAN, &payload, K_FOREVER);
+	err = zbus_chan_pub(&PAYLOAD_CHAN, &payload, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/button/button.c
+++ b/app/src/modules/button/button.c
@@ -40,7 +40,7 @@ static void send_button_payload(void)
 		return;
 	}
 
-	err = zbus_chan_pub(&PAYLOAD_CHAN, &payload, K_FOREVER);
+	err = zbus_chan_pub(&PAYLOAD_CHAN, &payload, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/environmental/environmental.c
+++ b/app/src/modules/environmental/environmental.c
@@ -177,7 +177,7 @@ static void sample(void)
 
 	LOG_DBG("Submitting payload");
 
-	int err = zbus_chan_pub(&PAYLOAD_CHAN, &payload, K_NO_WAIT);
+	int err = zbus_chan_pub(&PAYLOAD_CHAN, &payload, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/fota/fota.c
+++ b/app/src/modules/fota/fota.c
@@ -191,7 +191,7 @@ static void state_poll_and_process_entry(void *o)
 	/* Notify the rest of the system that FOTA processing is starting */
 	enum fota_status fota_status = FOTA_STATUS_PROCESSING_START;
 
-	int err = zbus_chan_pub(&FOTA_STATUS_CHAN, &fota_status, K_NO_WAIT);
+	int err = zbus_chan_pub(&FOTA_STATUS_CHAN, &fota_status, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -206,7 +206,7 @@ static void state_poll_and_process_entry(void *o)
 			LOG_ERR("nrf_cloud_fota_poll_process failed: %d", err);
 		}
 
-		err = zbus_chan_pub(&PRIV_FOTA_CHAN, &evt, K_NO_WAIT);
+		err = zbus_chan_pub(&PRIV_FOTA_CHAN, &evt, K_SECONDS(1));
 		if (err) {
 			LOG_ERR("zbus_chan_pub, error: %d", err);
 			SEND_FATAL_ERROR();
@@ -243,7 +243,7 @@ static void state_poll_and_process_exit(void *o)
 
 	ARG_UNUSED(o);
 
-	int err = zbus_chan_pub(&FOTA_STATUS_CHAN, &fota_status, K_NO_WAIT);
+	int err = zbus_chan_pub(&FOTA_STATUS_CHAN, &fota_status, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -258,7 +258,7 @@ static void state_reboot_pending_entry(void *o)
 	enum fota_status fota_status = FOTA_STATUS_REBOOT_PENDING;
 
 	/* Notify the rest of the system that a reboot is pending */
-	err = zbus_chan_pub(&FOTA_STATUS_CHAN, &fota_status, K_NO_WAIT);
+	err = zbus_chan_pub(&FOTA_STATUS_CHAN, &fota_status, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -288,7 +288,7 @@ static void fota_reboot(enum nrf_cloud_fota_reboot_status status)
 
 	LOG_INF("Reboot requested with FOTA status %d", status);
 
-	err = zbus_chan_pub(&PRIV_FOTA_CHAN, &evt, K_NO_WAIT);
+	err = zbus_chan_pub(&PRIV_FOTA_CHAN, &evt, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -307,7 +307,7 @@ static void fota_error(enum nrf_cloud_fota_status status, const char *const stat
 
 	LOG_ERR("FOTA error: %d, details: %s", status, status_details);
 
-	err = zbus_chan_pub(&PRIV_FOTA_CHAN, &evt, K_NO_WAIT);
+	err = zbus_chan_pub(&PRIV_FOTA_CHAN, &evt, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/network/network.c
+++ b/app/src/modules/network/network.c
@@ -203,7 +203,7 @@ static void sample_network_quality(void)
 
 	LOG_DBG("Submitting payload");
 
-	int err = zbus_chan_pub(&PAYLOAD_CHAN, &payload, K_NO_WAIT);
+	int err = zbus_chan_pub(&PAYLOAD_CHAN, &payload, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/transport/transport.c
+++ b/app/src/modules/transport/transport.c
@@ -266,7 +266,7 @@ static void state_disconnected_entry(void *o)
 
 	LOG_DBG("%s", __func__);
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_status, K_NO_WAIT);
+	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_status, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -361,7 +361,7 @@ static void state_connected_ready_entry(void *o)
 
 	LOG_DBG("%s", __func__);
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_status, K_NO_WAIT);
+	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_status, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();
@@ -438,7 +438,7 @@ static void state_connected_paused_entry(void *o)
 
 	LOG_DBG("%s", __func__);
 
-	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_status, K_NO_WAIT);
+	err = zbus_chan_pub(&CLOUD_CHAN, &cloud_status, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();

--- a/app/src/modules/trigger/trigger.c
+++ b/app/src/modules/trigger/trigger.c
@@ -131,7 +131,7 @@ static void frequent_poll_state_duration_timer_handler(struct k_timer * timer_id
 
 	LOG_DBG("Frequent poll duration timer expired");
 
-	err = zbus_chan_pub(&PRIV_TRIGGER_CHAN, &unused, K_NO_WAIT);
+	err = zbus_chan_pub(&PRIV_TRIGGER_CHAN, &unused, K_SECONDS(1));
 	if (err) {
 		LOG_ERR("zbus_chan_pub, error: %d", err);
 		SEND_FATAL_ERROR();


### PR DESCRIPTION
Use 1 second as the default timeout when publishing on a zbus channel. Previously, different values were used, sometimes `K_NO_WAIT`. Using `K_NO_WAIT` is problematic if the channel is locked by another context when calling `zbus_chan_pub`. If this occurs, the API fails, which we currently handle by asserting. Increasing the timeout increases the chance of the API succeeding.