### PR TITLE
workflow: fix memfault sw type

### DIFF
--- a/.github/workflows/attach_release_assets.yml
+++ b/.github/workflows/attach_release_assets.yml
@@ -15,6 +15,7 @@ jobs:
     secrets: inherit
     with:
       build_bl_update: true
+      memfault_sw_type: "hello.nrfcloud.com"
 
   attach-assets:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ on:
         type: boolean
         required: false
         default: false
+      memfault_sw_type:
+        type: string
+        required: false
+        default: "hello.nrfcloud.com-ci"
     outputs:
       run_id:
         description: The run ID of the workflow to fetch artifacts from
@@ -72,6 +76,14 @@ jobs:
           python3 scripts/app_version.py ${GITHUB_REF_NAME} > app/VERSION
           cat app/VERSION
 
+      - name: Set MEMFAULT_SW_TYPE from inputs or use default
+        run: |
+          if [ -z "${{ inputs.memfault_sw_type }}" ]; then
+            echo "MEMFAULT_SW_TYPE=hello.nrfcloud.com-ci" >> $GITHUB_ENV
+          else
+            echo "MEMFAULT_SW_TYPE=${{ inputs.memfault_sw_type }}" >> $GITHUB_ENV
+          fi
+
       - name: Apply nrf_wifi HAL patch
         run: git apply thingy91x-oob/scripts/nrf_wifi_hal_memory_leak_fix.patch --directory=nrfxlib
 
@@ -81,6 +93,7 @@ jobs:
           echo "CONFIG_MEMFAULT_NCS_PROJECT_KEY=\"${{ secrets.MEMFAULT_PROJECT_KEY }}\"" >> overlay-memfault.conf
           echo CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y >> overlay-memfault.conf
           echo CONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.VERSION }}\" >> overlay-memfault.conf
+          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}\" >> overlay-memfault.conf
           west build -b thingy91x/nrf9151/ns -p --sysbuild -- -DEXTRA_CONF_FILE="overlay-memfault.conf"
 
       - name: Create nrf91 Bootloader HEX file


### PR DESCRIPTION
memfault sw type needs to be configured in MEMFAULT_NCS_FW_TYPE
Not only when pushing elf with --software-type arg