### PR TITLE
modules: Use dedicated workqueue for LED PWM handling

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -50,6 +50,12 @@ CONFIG_LTE_PSM_REQ_RPTAU_SECONDS=7200
 # downlink data, there is no need for prolonged active paging after the RRC connection release.
 CONFIG_LTE_PSM_REQ_RAT_SECONDS=6
 
+# Enable eDRX (Extended Discontinuous Reception)
+CONFIG_LTE_EDRX_REQ=y
+# "0000" is 5.12 s
+CONFIG_LTE_EDRX_REQ_VALUE_LTE_M="0000"
+CONFIG_LTE_EDRX_REQ_VALUE_NBIOT="0000"
+
 # Modem library
 CONFIG_NRF_MODEM_LIB=y
 

--- a/app/src/modules/fota/fota.c
+++ b/app/src/modules/fota/fota.c
@@ -324,7 +324,6 @@ static void fota_status(enum nrf_cloud_fota_status status, const char *const sta
 	case NRF_CLOUD_FOTA_SUCCEEDED:
 		LOG_DBG("Firmware update succeeded");
 
-		/* Dont */
 		status_events_notify(FOTA_STATUS_STOP);
 		return;
 	default:

--- a/app/src/modules/led/Kconfig.led
+++ b/app/src/modules/led/Kconfig.led
@@ -11,6 +11,10 @@ menuconfig APP_LED
 
 if APP_LED
 
+config APP_LED_PWM_WORKQUEUE_STACK_SIZE
+	int "LED PWM WQ stack size"
+	default 768
+
 module = APP_LED
 module-str = LED
 source "subsys/logging/Kconfig.template.log_config"

--- a/app/src/modules/transport/transport.c
+++ b/app/src/modules/transport/transport.c
@@ -227,7 +227,7 @@ static void state_running_entry(void *o)
 	k_work_queue_init(&transport_queue);
 	k_work_queue_start(&transport_queue, stack_area,
 			   K_THREAD_STACK_SIZEOF(stack_area),
-			   K_HIGHEST_APPLICATION_THREAD_PRIO,
+			   K_LOWEST_APPLICATION_THREAD_PRIO,
 			   NULL);
 
 	err = nrf_cloud_coap_init();

--- a/tests/on_target/tests/test_fota.py
+++ b/tests/on_target/tests/test_fota.py
@@ -24,7 +24,7 @@ FULL_MFW_BUNDLEID = "MDM_FULL*bdd24c80*mfw_nrf91x1_full_2.0.1"
 
 WAIT_FOR_FOTA_AVAILABLE = 60 * 4
 APP_FOTA_TIMEOUT = 60 * 10
-FULL_MFW_FOTA_TIMEOUT = 60 * 20
+FULL_MFW_FOTA_TIMEOUT = 60 * 30
 
 
 def wait_for_fota_available(t91x_board):


### PR DESCRIPTION
After modem FOTA the download client thread tries to put the modem into bootloader mode. However, this times out. Suspected reason is that the LED PWM handling is blocking the download client thread due to being scheduled in tight steps via the system workqueue (cooperative).

Also, reinstate eDRX setting in prj.conf that was removed by mistake.

AND, increase full modem test timeout to 30 minutes as it occasionally times out. (Slow download)