### PR TITLE
compliance: Block reference to sdk-nrf by pull request

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -27,6 +27,15 @@ jobs:
         west config build.sysbuild True
         west update -o=--depth=1 -n
 
+    - name: Check for valid sdk-nrf reference
+      run: |
+        if grep -r "revision: pull/" manifest.yml; then
+          echo "Error: Forbidden 'pull/' found in sdk-nrf revision!"
+          exit 1
+        else
+          echo "sdk-nrf revision is valid."
+        fi
+
     - name: Run Compliance Tests
       continue-on-error: true
       id: compliance


### PR DESCRIPTION
Block references to sdk-nrf by pull requests. Referring to pull requests is not a good practice as they can change. Bisectability is broken if the pull request changes or is removed after merging.