### PR TITLE
modules: fota: Re-apply modem image after FOTA

### DIFF
--- a/app/src/modules/app/Kconfig.app
+++ b/app/src/modules/app/Kconfig.app
@@ -10,11 +10,11 @@ config APP_MODULE_THREAD_STACK_SIZE
 
 config APP_MODULE_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout seconds"
-	default 120
+	default 180
 
 config APP_MODULE_EXEC_TIME_SECONDS_MAX
 	int "Maximum execution time seconds"
-	default 60
+	default 120
 	help
 	  Maximum time allowed for a single execution of the module thread loop.
 

--- a/app/src/modules/fota/Kconfig.fota
+++ b/app/src/modules/fota/Kconfig.fota
@@ -15,11 +15,11 @@ config APP_FOTA_THREAD_STACK_SIZE
 
 config APP_FOTA_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout seconds"
-	default 120
+	default 210
 
 config APP_FOTA_EXEC_TIME_SECONDS_MAX
 	int "Maximum execution time seconds"
-	default 90
+	default 180
 	help
 	  Watchdog timeout in seconds for a state machine run.
 

--- a/app/src/modules/transport/Kconfig.transport
+++ b/app/src/modules/transport/Kconfig.transport
@@ -37,11 +37,11 @@ config APP_TRANSPORT_POLL_INTERVAL_SECONDS
 
 config APP_TRANSPORT_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout seconds"
-	default 120
+	default 180
 
 config APP_TRANSPORT_EXEC_TIME_SECONDS_MAX
 	int "Maximum execution time seconds"
-	default 60
+	default 120
 	help
 	  Maximum time allowed for a single execution of the module's thread loop.
 

--- a/tests/on_target/tests/test_fota.py
+++ b/tests/on_target/tests/test_fota.py
@@ -72,7 +72,7 @@ def run_fota_resumption(t91x_board, fota_type):
 def run_fota_fixture(t91x_board, hex_file):
     def _run_fota(bundleId, fota_type, fotatimeout=APP_FOTA_TIMEOUT, test_fota_resumption=False):
         flash_device(os.path.abspath(hex_file))
-        time.sleep(5)
+        time.sleep(10)
         t91x_board.uart.xfactoryreset()
         t91x_board.uart.flush()
         reset_device()


### PR DESCRIPTION
Modem validation (shutdown and reinit in bootloader mode) fails quite often. Fix this by re-applying the modem image again after FOTA has finished.