### PR TITLE
app: Revert main stack reduction

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -13,6 +13,7 @@ CONFIG_DK_LIBRARY=y
 CONFIG_PWM=y
 
 # Heap and stacks
+CONFIG_MAIN_STACK_SIZE=4096
 # Extended AT host/monitor stack/heap sizes since some nrf_cloud credentials are longer than 1024 bytes.
 CONFIG_AT_MONITOR_HEAP_SIZE=2048
 # Wifi scan requires extended heap size


### PR DESCRIPTION
Revert main stack reduction to default 1024 and set it to 4096.