### PR TITLE
ci: sanitize artifact names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,25 +118,31 @@ jobs:
       - name: Create nrf53 merged_domains HEX file
         run: |
           python3 zephyr/scripts/build/mergehex.py -o \
-            $(pwd)/thingy91x-oob/app/build/hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf53-connectivity-bridge.hex \
+            $(pwd)/thingy91x-oob/app/build/connectivity-bridge-${{ env.VERSION }}-thingy91x-nrf53-merged.hex \
             $(pwd)/nrf/applications/connectivity_bridge/build/merged_CPUNET.hex \
             $(pwd)/nrf/applications/connectivity_bridge/build/merged.hex
+          cp $(pwd)/nrf/applications/connectivity_bridge/build/merged_CPUNET.hex \
+            $(pwd)/thingy91x-oob/app/build/connectivity-bridge-${{ env.VERSION }}-thingy91x-nrf53-net.hex
+          cp $(pwd)/nrf/applications/connectivity_bridge/build/merged.hex \
+            $(pwd)/thingy91x-oob/app/build/connectivity-bridge-${{ env.VERSION }}-thingy91x-nrf53-app.hex
 
       - name: Create nrf53 Bootloader HEX file
         run: |
           python3 zephyr/scripts/build/mergehex.py -o \
-            $(pwd)/thingy91x-oob/app/build/hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf53-bootloader.hex \
+            $(pwd)/thingy91x-oob/app/build/connectivity-bridge-${{ env.VERSION }}-thingy91x-nrf53-app-bootloader.hex \
             $(pwd)/nrf/applications/connectivity_bridge/build/b0_container.hex \
             $(pwd)/nrf/applications/connectivity_bridge/build/signed_by_b0_mcuboot.hex \
             $(pwd)/nrf/applications/connectivity_bridge/build/signed_by_b0_s1_image.hex \
-            $(pwd)/nrf/applications/connectivity_bridge/build/app_provision.hex \
+            $(pwd)/nrf/applications/connectivity_bridge/build/app_provision.hex
+          python3 zephyr/scripts/build/mergehex.py -o \
+            $(pwd)/thingy91x-oob/app/build/connectivity-bridge-${{ env.VERSION }}-thingy91x-nrf53-net-bootloader.hex \
             $(pwd)/nrf/applications/connectivity_bridge/build/b0n_container.hex \
             $(pwd)/nrf/applications/connectivity_bridge/build/net_provision.hex
 
       - name: Copy nrf53 DFU file
         run: |
           cp $(pwd)/nrf/applications/connectivity_bridge/build/dfu_application.zip \
-            $(pwd)/thingy91x-oob/app/build/hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf53-dfu.zip
+            $(pwd)/thingy91x-oob/app/build/connectivity-bridge-${{ env.VERSION }}-thingy91x-nrf53-dfu.zip
 
       - name: Apply Connectivity Bridge patch for bootloader update
         working-directory: nrf
@@ -155,19 +161,19 @@ jobs:
           west twister -T ../nrf/applications/connectivity_bridge \
             --test applications.connectivity_bridge.bootloader_update -v -p thingy91x/nrf5340/cpuapp --inline-logs
           cp twister-out/thingy91x_nrf5340_cpuapp/applications.connectivity_bridge.bootloader_update/dfu_mcuboot.zip \
-            app/build/hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf53-bootloader.zip
+            app/build/connectivity_bridge-${{ env.VERSION }}-thingy91x-nrf53-bootloader.zip
           cp twister-out/thingy91x_nrf5340_cpuapp/applications.connectivity_bridge.bootloader_update/dfu_application.zip \
-            app/build/hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf53-connectivity-bridge-verbose.zip
+            app/build/connectivity_bridge-${{ env.VERSION }}-thingy91x-nrf53-verbose.zip
 
       - name: Rename artifacts
         working-directory: thingy91x-oob/app/build
         run: |
-          cp merged.hex hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app.hex
-          cp app/zephyr/.config hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app.config
-          cp app/zephyr/zephyr.signed.bin hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app_update_signed.bin
-          cp app/zephyr/zephyr.signed.hex hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app_update_signed.hex
-          cp app/zephyr/zephyr.elf hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-debug-app.elf
-          cp b0_s0_s1_merged.hex hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-bootloader.hex
+          cp merged.hex hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf91.hex
+          cp app/zephyr/.config hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf91.config
+          cp app/zephyr/zephyr.signed.bin hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf91-update-signed.bin
+          cp app/zephyr/zephyr.signed.hex hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf91-update-signed.hex
+          cp app/zephyr/zephyr.elf hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf91.elf
+          cp b0_s0_s1_merged.hex hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf91-bootloader.hex
           cp dfu_application.zip hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf91-dfu.zip
 
       - name: Upload artifact
@@ -178,6 +184,7 @@ jobs:
           if-no-files-found: error
           path: |
             thingy91x-oob/app/build/hello.nrfcloud.com-*.*
+            thingy91x-oob/app/build/connectivity-bridge-*.*
 
       - name: Print run-id and fw version
         run: |

--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -98,7 +98,7 @@ jobs:
               upload-mcu-symbols \
               --software-type hello.nrfcloud.com-ci \
               --software-version ${{ inputs.artifact_fw_version }} \
-              hello.nrfcloud.com-${{ inputs.artifact_fw_version }}-thingy91x-debug-app.elf
+              hello.nrfcloud.com-${{ inputs.artifact_fw_version }}-thingy91x-nrf91.elf
 
       - name: Run UART tests
         working-directory: thingy91x-oob/tests/on_target
@@ -143,10 +143,10 @@ jobs:
           SEGGER_NRF53: ${{ secrets.SEGGER_DUT_2_EXT_DBG }}
           SEGGER_NRF91: ${{ secrets.SEGGER_DUT_2_NRF91 }}
           UART_ID: ${{ secrets.UART_DUT_2 }}
-          NRF53_HEX_FILE: artifacts/hello.nrfcloud.com-${{ inputs.artifact_fw_version }}-thingy91x-nrf53-connectivity-bridge.hex
-          NRF53_APP_UPDATE_ZIP: artifacts/hello.nrfcloud.com-${{ inputs.artifact_fw_version }}-thingy91x-nrf53-connectivity-bridge-verbose.zip
-          NRF53_BL_UPDATE_ZIP: artifacts/hello.nrfcloud.com-${{ inputs.artifact_fw_version }}-thingy91x-nrf53-bootloader.zip
-          NRF91_HEX_FILE: artifacts/hello.nrfcloud.com-${{ inputs.artifact_fw_version }}-thingy91x-bootloader.hex
+          NRF53_HEX_FILE: artifacts/connectivity-bridge-${{ inputs.artifact_fw_version }}-thingy91x-nrf53-merged.hex
+          NRF53_APP_UPDATE_ZIP: artifacts/connectivity-bridge-${{ inputs.artifact_fw_version }}-thingy91x-nrf53-verbose.zip
+          NRF53_BL_UPDATE_ZIP: artifacts/connectivity-bridge-${{ inputs.artifact_fw_version }}-thingy91x-nrf53-bootloader.zip
+          NRF91_HEX_FILE: artifacts/hello.nrfcloud.com-${{ inputs.artifact_fw_version }}-thingy91x-nrf91-bootloader.hex
           NRF91_APP_UPDATE_ZIP: artifacts/hello.nrfcloud.com-${{ inputs.artifact_fw_version }}-thingy91x-nrf91-dfu.zip
           NRF91_BL_UPDATE_ZIP: artifacts/hello.nrfcloud.com-${{ inputs.artifact_fw_version }}-thingy91x-nrf91-bootloader.zip
 

--- a/.github/workflows/publish-symbol-files-to-memfault.yml
+++ b/.github/workflows/publish-symbol-files-to-memfault.yml
@@ -38,4 +38,4 @@ jobs:
               upload-mcu-symbols \
               --software-type hello.nrfcloud.com \
               --software-version ${{ inputs.version }} \
-              hello.nrfcloud.com-${{ inputs.version }}-thingy91x-debug-app.elf
+              hello.nrfcloud.com-${{ inputs.version }}-thingy91x-nrf91.elf

--- a/.github/workflows/register-firmware-bundles.mjs
+++ b/.github/workflows/register-firmware-bundles.mjs
@@ -10,7 +10,7 @@ const version = (process.argv[process.argv.length - 1] ?? "").trim();
 console.log(`Publishing release version`, version);
 
 const nameRegEx = new RegExp(
-  `^hello\.nrfcloud\.com-${version}-thingy91x-((?<configuration>.+)-)?app_update_signed\.bin$`
+  `^hello\.nrfcloud\.com-${version}-thingy91x-nrf91-((?<configuration>.+)-)?update-signed\.bin$`
 );
 
 const assets = fs

--- a/tests/on_target/README.md
+++ b/tests/on_target/README.md
@@ -7,7 +7,7 @@
 docker pull ghcr.io/hello-nrfcloud/firmware:v2.0.0-preview42
 cd <path_to_oob_dir>
 west build -p -b thingy91x/nrf9151/ns app
-cp build/merged.hex tests/on_target/artifacts/hello.nrfcloud.com-aaa000-thingy91x-debug-app.hex
+cp build/merged.hex tests/on_target/artifacts/hello.nrfcloud.com-aaa000-thingy91x-nrf91.hex
 docker run --rm -it \
   --privileged \
   -v /dev:/dev:rw \

--- a/tests/on_target/tests/conftest.py
+++ b/tests/on_target/tests/conftest.py
@@ -70,7 +70,7 @@ def t91x_board():
 def hex_file():
     # Search for the firmware hex file in the artifacts folder
     artifacts_dir = "artifacts"
-    hex_pattern = r"hello\.nrfcloud\.com-[a-f0-9]+-thingy91x-debug-app\.hex"
+    hex_pattern = r"hello\.nrfcloud\.com-[a-f0-9]+-thingy91x-nrf91\.hex"
 
     for file in os.listdir(artifacts_dir):
         if re.match(hex_pattern, file):


### PR DESCRIPTION
Make the artifact names more obivous.
Also, for nRF5340 builds, separate HEX files for
APP core and NET core are released so nrfutil-device can be used.