### PR TITLE
ci: fix connectivity-bridge release assets

### DIFF
--- a/.github/workflows/attach_release_assets.yml
+++ b/.github/workflows/attach_release_assets.yml
@@ -33,7 +33,9 @@ jobs:
           uses: softprops/action-gh-release@v2
           with:
             fail_on_unmatched_files: true
-            files: hello.nrfcloud.com-*.*
+            files: |
+              hello.nrfcloud.com-*.*
+              connectivity-bridge*.*
 
         - name: Trigger workflow that publishes firmware bundles to nRF Cloud
           working-directory: .github/workflows


### PR DESCRIPTION
The connectivity bridge assets have been missing since the renaming.