### PR TITLE
modules: app: Increase watchdog timeout

### DIFF
--- a/app/src/modules/app/Kconfig.app
+++ b/app/src/modules/app/Kconfig.app
@@ -10,11 +10,11 @@ config APP_MODULE_THREAD_STACK_SIZE
 
 config APP_MODULE_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout seconds"
-	default 180
+	default 210
 
 config APP_MODULE_EXEC_TIME_SECONDS_MAX
 	int "Maximum execution time seconds"
-	default 120
+	default 180
 	help
 	  Maximum time allowed for a single execution of the module thread loop.
 


### PR DESCRIPTION
Increase watchdog timeout to avoid blocking during CoAP requests.