### PR TITLE
Memfault fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
           echo CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y >> overlay-memfault.conf
           echo CONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.VERSION }}\" >> overlay-memfault.conf
           echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}\" >> overlay-memfault.conf
+          echo CONFIG_APP_MEMFAULT_UPLOAD_METRICS_ON_CLOUD_READY=y >> overlay-memfault.conf
           west build -b thingy91x/nrf9151/ns -p --sysbuild -- -DEXTRA_CONF_FILE="overlay-memfault.conf"
 
       - name: Create nrf91 Bootloader HEX file

--- a/app/src/modules/memfault/Kconfig.memfault
+++ b/app/src/modules/memfault/Kconfig.memfault
@@ -29,6 +29,16 @@ config APP_MEMFAULT_ZBUS_TIMEOUT_SECONDS
 	int "Wait for zbus timeout seconds"
 	default 60
 
+config APP_MEMFAULT_UPLOAD_METRICS_ON_CLOUD_READY
+	bool "Update metrics on cloud ready events"
+	help
+	  Update and upload metrics to Memfault when the cloud connection is ready.
+	  Note that this means that metrics will be uploaded every time network connection is
+	  established and cloud is connected. In poor network conditions, this may happen
+	  frequently and may consume a excessive amount of data and power.
+	  Also note that this only applies to metrics, not coredumps, which are uploaded
+	  regardless of this setting.
+
 module = APP_MEMFAULT
 module-str = Memfault
 source "subsys/logging/Kconfig.template.log_config"

--- a/app/src/modules/memfault/memfault.c
+++ b/app/src/modules/memfault/memfault.c
@@ -140,6 +140,13 @@ static void prepare_modem_trace_upload(void)
 
 static void on_connected(void)
 {
+	size_t core_dump_size = 0;
+
+	if (!memfault_coredump_has_valid_coredump(&core_dump_size) &&
+	    !IS_ENABLED(CONFIG_APP_MEMFAULT_UPLOAD_METRICS_ON_CLOUD_READY)) {
+		return;
+	}
+
 	/* Trigger collection of heartbeat data */
 	memfault_metrics_heartbeat_debug_trigger();
 
@@ -149,10 +156,8 @@ static void on_connected(void)
 	}
 
 #if defined(CONFIG_NRF_MODEM_LIB_TRACE)
-	size_t total_size = 0;
-
 	/* If there was a coredump, also send modem trace */
-	if (memfault_coredump_has_valid_coredump(&total_size)) {
+	if (memfault_coredump_has_valid_coredump(&core_dump_size)) {
 		prepare_modem_trace_upload();
 	}
 


### PR DESCRIPTION
Introduce option that controls whether data is uploaded on cloud
ready event or not. It's been observed that uploading data to
Memfault consumes a lot of data (and power) in poor network
conditions where cloud is toggling frequently between paused and
ready.