### PR TITLE
tests: on_target: no cloud check on network disconnect

### DIFF
--- a/tests/on_target/tests/test_uart_output.py
+++ b/tests/on_target/tests/test_uart_output.py
@@ -39,7 +39,6 @@ def test_uart_output(t91x_board, hex_file):
     ]
     patterns_lte_normal = [
             "network: Network connectivity established",
-            "transport: Connected to Cloud"
     ]
 
     # Boot


### PR DESCRIPTION
Cloud connection is valid even though network connection is intermittently lost.