### PR TITLE
workflow: Fix on_target tests to download multiple artifacts

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -73,7 +73,8 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: firmware
+          pattern: firmware-*
+          merge-multiple: true
           path: thingy91x-oob/tests/on_target/artifacts
           run-id: ${{ inputs.artifact_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The on_target workflow was not updated when introducing multiple upload artifacts in #381.