### PR TITLE
workflow: publish elf for debug version to memfault

### DIFF
--- a/.github/workflows/publish-symbol-files-to-memfault.yml
+++ b/.github/workflows/publish-symbol-files-to-memfault.yml
@@ -32,7 +32,7 @@ jobs:
 
       - run: node .github/workflows/fetch-release-assets.mjs ${{ inputs.version }}
 
-      - name: Publish symbol files
+      - name: Publish oob symbol files
         run: |
           source venv/bin/activate
           memfault \
@@ -43,3 +43,15 @@ jobs:
               --software-type hello.nrfcloud.com \
               --software-version ${{ inputs.version }} \
               hello.nrfcloud.com-${{ inputs.version }}-thingy91x-nrf91.elf
+
+      - name: Publish oob-debug symbol files
+        run: |
+          source venv/bin/activate
+          memfault \
+              --org-token ${{ secrets.MEMFAULT_ORGANIZATION_TOKEN }} \
+              --org ${{ vars.MEMFAULT_ORGANIZATION_SLUG }} \
+              --project ${{ vars.MEMFAULT_PROJECT_SLUG }} \
+              upload-mcu-symbols \
+              --software-type hello.nrfcloud.com \
+              --software-version ${{ inputs.version }} \
+              hello.nrfcloud.com-${{ inputs.version }}-debug-thingy91x-nrf91.elf


### PR DESCRIPTION
The debug version of the oob application was added to the attach release assets last week, but the symbol files (elf) was not uploaded to Memfault. This commit adds a step for uploading the elf for the debug build.