### PR TITLE
workflow: Add +debug to the debug version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,11 +100,12 @@ jobs:
       - name: Build nrf91 firmware
         working-directory: thingy91x-oob/app
         run: |
-          echo "CONFIG_MEMFAULT_NCS_PROJECT_KEY=\"${{ secrets.MEMFAULT_PROJECT_KEY }}\"" >> overlay-memfault.conf
-          echo CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y >> overlay-memfault.conf
-          echo CONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.VERSION }}\" >> overlay-memfault.conf
-          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}\" >> overlay-memfault.conf
-          west build -b thingy91x/nrf9151/ns -p --sysbuild -- -DEXTRA_CONF_FILE="overlay-memfault.conf"
+          cp overlay-memfault.conf overlay-memfault-oob.conf
+          echo "CONFIG_MEMFAULT_NCS_PROJECT_KEY=\"${{ secrets.MEMFAULT_PROJECT_KEY }}\"" >> overlay-memfault-oob.conf
+          echo CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y >> overlay-memfault-oob.conf
+          echo CONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.VERSION }}\" >> overlay-memfault-oob.conf
+          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}\" >> overlay-memfault-oob.conf
+          west build -b thingy91x/nrf9151/ns -p --sysbuild -- -DEXTRA_CONF_FILE="overlay-memfault-oob.conf"
 
       - name: Create nrf91 Bootloader HEX file
         run: |
@@ -141,8 +142,13 @@ jobs:
         if: ${{ inputs.build_debug }}
         working-directory: thingy91x-oob/app
         run: |
-          echo CONFIG_APP_MEMFAULT_UPLOAD_METRICS_ON_CLOUD_READY=y >> overlay-memfault.conf
-          west build -p -b thingy91x/nrf9151/ns -p --sysbuild -- -DEXTRA_CONF_FILE="overlay-memfault.conf;overlay-modemtrace.conf;overlay-etb.conf"
+          cp overlay-memfault.conf overlay-memfault-debug.conf
+          echo "CONFIG_MEMFAULT_NCS_PROJECT_KEY=\"${{ secrets.MEMFAULT_PROJECT_KEY }}\"" >> overlay-memfault-debug.conf
+          echo CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y >> overlay-memfault-debug.conf
+          echo CONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.VERSION }}+debug\" >> overlay-memfault-debug.conf
+          echo CONFIG_MEMFAULT_NCS_FW_TYPE=\"${{ env.MEMFAULT_SW_TYPE }}\" >> overlay-memfault-debug.conf
+          echo CONFIG_APP_MEMFAULT_UPLOAD_METRICS_ON_CLOUD_READY=y >> overlay-memfault-debug.conf
+          west build -p -b thingy91x/nrf9151/ns -p --sysbuild -- -DEXTRA_CONF_FILE="overlay-memfault-debug.conf;overlay-modemtrace.conf;overlay-etb.conf"
 
       - name: Create nrf91 debug bootloader HEX file
         if: ${{ inputs.build_debug }}

--- a/.github/workflows/publish-symbol-files-to-memfault.yml
+++ b/.github/workflows/publish-symbol-files-to-memfault.yml
@@ -53,5 +53,5 @@ jobs:
               --project ${{ vars.MEMFAULT_PROJECT_SLUG }} \
               upload-mcu-symbols \
               --software-type hello.nrfcloud.com \
-              --software-version ${{ inputs.version }} \
+              --software-version ${{ inputs.version }}+debug \
               hello.nrfcloud.com-${{ inputs.version }}-debug-thingy91x-nrf91.elf


### PR DESCRIPTION
Add +debug to the version string when building the debug version and when uploading the debug elf to memfault.