### PR TITLE
modules: app: Incrase payload buffer

### DIFF
--- a/app/src/modules/app/Kconfig.app
+++ b/app/src/modules/app/Kconfig.app
@@ -20,6 +20,6 @@ config APP_MODULE_EXEC_TIME_SECONDS_MAX
 
 config APP_MODULE_RECV_BUFFER_SIZE
 	int "Receive buffer size"
-	default 512
+	default 1024
 
 endmenu


### PR DESCRIPTION
Incrase payload buffer to 1024 bytes.
Its been observer that responses from nrf cloud gets truncated when requesting the full shadow post boot.

Increase the payload buffer to 1024 bytes to avoid truncation.