### PR TITLE
app: Increase app module stack size

### DIFF
--- a/app/src/modules/app/Kconfig.app
+++ b/app/src/modules/app/Kconfig.app
@@ -6,7 +6,7 @@ menu "App"
 
 config APP_MODULE_THREAD_STACK_SIZE
 	int "Thread stack size"
-	default 2500
+	default 2700
 
 config APP_MODULE_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout seconds"


### PR DESCRIPTION
The stack size was right on the limit for overflowing. Increasing to avoid that.