### PR TITLE
workflow: Correct filename for debug elf

### DIFF
--- a/.github/workflows/publish-symbol-files-to-memfault.yml
+++ b/.github/workflows/publish-symbol-files-to-memfault.yml
@@ -54,4 +54,4 @@ jobs:
               upload-mcu-symbols \
               --software-type hello.nrfcloud.com \
               --software-version ${{ inputs.version }}+debug \
-              hello.nrfcloud.com-${{ inputs.version }}-debug-thingy91x-nrf91.elf
+              hello.nrfcloud.com-${{ inputs.version }}+debug-thingy91x-nrf91.elf


### PR DESCRIPTION
The filename for the debug elf has a '+', not a '-'.