### PR TITLE
memfault: Clear modem traces after boot on no valid coredump

### DIFF
--- a/app/src/common/message_channel.h
+++ b/app/src/common/message_channel.h
@@ -29,7 +29,7 @@ extern "C" {
 	if (is_watchdog_timeout) {						\
 		IF_ENABLED(CONFIG_MEMFAULT, (MEMFAULT_SOFTWARE_WATCHDOG()));	\
 	}									\
-	k_sleep(K_SECONDS(5));							\
+	k_sleep(K_SECONDS(10));							\
 	__ASSERT(false, "SEND_FATAL_ERROR() macro called");			\
 } while (0)
 
@@ -42,7 +42,7 @@ extern "C" {
 	enum error_type type = ERROR_IRRECOVERABLE;				\
 	(void)zbus_chan_pub(&ERROR_CHAN, &type, K_SECONDS(10));			\
 	LOG_PANIC();								\
-	k_sleep(K_SECONDS(5));							\
+	k_sleep(K_SECONDS(10));							\
 } while (0)
 
 struct payload {

--- a/app/src/modules/memfault/memfault.c
+++ b/app/src/modules/memfault/memfault.c
@@ -71,12 +71,19 @@ NRF_MODEM_LIB_ON_INIT(memfault_init_hook, on_modem_lib_init, NULL)
 
 static void on_modem_lib_init(int ret, void *ctx)
 {
+	int err;
+
 	if (memfault_coredump_has_valid_coredump(NULL)) {
 		return;
 	}
 
-	int err = modem_trace_enable();
+	err = nrf_modem_lib_trace_clear();
+	if (err) {
+		LOG_ERR("Failed to clear modem trace data: %d", err);
+		return;
+	}
 
+	err = modem_trace_enable();
 	if (err) {
 		LOG_ERR("Failed to enable modem traces: %d", err);
 		return;


### PR DESCRIPTION
Clear modem traces after boot on no valid coredump. This is to prevent any issues related to non-volitile variables in the modem trace flash backend such as offset and size.

We have observed that some traces are corrupted and to potentially improve this we clear the modem traces after boot if there is no valid coredump.

Increase timeout when crashing to 10 seconds to allow more time for memfault to save the coredump and modem traces to be saved to flash.