### PR TITLE
workflows: sonarcloud: Fecth Wi-Fi blob

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -40,6 +40,7 @@ jobs:
             west config manifest.group-filter +bsec
             west config build.sysbuild True
             west update -o=--depth=1 -n
+            west blobs fetch hal_nordic
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The binary blob is needed to build Wi-Fi stack.