### PR TITLE
README: adding missing steps in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ environment. Follow the official
 
 ### Initialization
 
+Before initializing start the toolchain environment:
+
+```shell
+nrfutil toolchain-manager launch --shell
+```
+
 The first step is to initialize the workspace folder (`thingy91x-oob`) where the
 `firmware` project and all nRF Connect SDK modules will be cloned. Run the
 following command:
@@ -40,6 +46,12 @@ west config build.sysbuild True
 ```
 
 ### Building and running
+
+First change folder:
+
+```shell
+cd project
+```
 
 To build the application, run the following command:
 

--- a/tests/on_target/README.md
+++ b/tests/on_target/README.md
@@ -17,6 +17,8 @@ docker run --rm -it \
   /bin/bash
 ```
 
+NOTE: The tests have been tested on Ubuntu 22.04. For details on how to install Docker please refer to the Docker documentation https://docs.docker.com/engine/install/ubuntu/
+
 ### Verify nrfutil/jlink works
 ```shell
 JLinkExe -V
@@ -27,6 +29,11 @@ nrfutil -V
 ```shell
 cd thingy91x-oob/tests/on_target
 pip install -r requirements.txt --break-system-packages
+```
+
+### Get SEGGER ID
+```shell
+nrfutil device list
 ```
 
 ### Run UART tests


### PR DESCRIPTION

This add missing parts regarding getting started and on_target testing.

Signed-off-by: David Dilner <david.dilner@nordicsemi.no>