### PR TITLE
overlay-modemtrace.conf: Use dev security tag

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -30,3 +30,9 @@ add_subdirectory_ifdef(CONFIG_APP_SHELL src/modules/shell)
 
 # Include Memfault configuration folder
 zephyr_include_directories(config)
+
+if (CONFIG_NRF_CLOUD_COAP_SEC_TAG >= 2147483648) && (CONFIG_NRF_CLOUD_COAP_SEC_TAG <= 2147483667)
+	message(WARNING "CONFIG_NRF_CLOUD_COAP_SEC_TAG is set to a developer security tag. "
+			"TLS traffic can now be decrypted with Nordic tools. "
+			"This should only be used during development and testing.")
+endif()

--- a/app/overlay-modemtrace.conf
+++ b/app/overlay-modemtrace.conf
@@ -28,3 +28,8 @@ CONFIG_NRF_MODEM_LIB_TRACE_BACKEND_FLASH_PARTITION_SIZE=0xFF000
 
 # Enable modem trace shell commands
 CONFIG_NRF_MODEM_LIB_SHELL_TRACE=y
+
+# Set nRF Cloud CoAP security tag to a dev tag to enable decoded DTLS traces.
+# It is required that the nRF Cloud CoAP server certificate has been provisioned to the sec tag.
+CONFIG_NRF_CLOUD_COAP_SEC_TAG=2147483667
+CONFIG_NRF_CLOUD_COAP_JWT_SEC_TAG=4242


### PR DESCRIPTION
Set nRF Cloud CoAP security tag to a dev tag to
enable decoded DTLS traces. Dev tag for JWT generation is kept at 4242.