### PR TITLE
docker: Disconnect firmware releases and docker images

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -2,7 +2,7 @@ name: Docker Image Build and Publish
 on:
   push:
     tags:
-        - 'v*'
+        - 'docker-v*'
 
 jobs:
   build-docker-image:


### PR DESCRIPTION
Currently a new target-test docker image is built on every firmware release. Change this to build new docker image when a 'docker-vx.y.z' tag is pushed.