### PR TITLE
modules: network: Increase watchdog timeout

### DIFF
--- a/app/src/modules/network/Kconfig.network
+++ b/app/src/modules/network/Kconfig.network
@@ -13,11 +13,11 @@ config APP_NETWORK_THREAD_STACK_SIZE
 
 config APP_NETWORK_WATCHDOG_TIMEOUT_SECONDS
 	int "Watchdog timeout seconds"
-	default 120
+	default 600
 
 config APP_NETWORK_EXEC_TIME_SECONDS_MAX
 	int "Maximum execution time seconds"
-	default 30
+	default 570
 	help
 	  Maximum time allowed for a single execution of the module's thread loop.
 


### PR DESCRIPTION
Increase watchdog timeout to 600 seconds to accommodate for CONEVAL that can take up to 10 minutes (conservatively) in NB-IoT when there is an ongoing cell search.

See NRF91-2230