### PR TITLE
tests: on_target: add missing markers

### DIFF
--- a/tests/on_target/tests/pytest.ini
+++ b/tests/on_target/tests/pytest.ini
@@ -3,5 +3,7 @@ markers =
     dut1: device used for uart and fota tests
     dut2: device used for dfu tests
     uart: uart tests
+    conn_bridge: connectivity bridge tests
+    dfu: dfu tests
     fota: standard fota tests
     fullmfw_fota: fullmfw fota tests


### PR DESCRIPTION
adds missing markers for DFU and connectivity bridge