### PR TITLE
ci: Bump nRF53 BL version to 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: robinraju/release-downloader@v1
         with:
           tag: 'v2.0.0-preview58'
-          fileName: 'nrf53-bl-v2-*.hex'
+          fileName: 'nrf53-bl-v3-*.hex'
 
       - uses: robinraju/release-downloader@v1
         with:
@@ -187,7 +187,7 @@ jobs:
       - name: Build nrf53 firmware
         working-directory: nrf/applications/connectivity_bridge
         run: |
-          west build -b thingy91x/nrf5340/cpuapp -p --sysbuild -- -Dmcuboot_CONFIG_FW_INFO_FIRMWARE_VERSION=2 -DCONFIG_BUILD_S1_VARIANT=y
+          west build -b thingy91x/nrf5340/cpuapp -p --sysbuild -- -Dmcuboot_CONFIG_FW_INFO_FIRMWARE_VERSION=3 -DCONFIG_BUILD_S1_VARIANT=y
 
       - name: Create nrf53 merged_domains HEX file
         run: |
@@ -235,7 +235,7 @@ jobs:
           cp twister-out/thingy91x_nrf9151_ns/app/app.build.bootloader_update/dfu_mcuboot.zip \
             hello.nrfcloud.com-${{ env.VERSION }}-thingy91x-nrf91-bootloader.zip
           rm -rf twister-out
-          west build -b thingy91x/nrf5340/cpuapp -p --sysbuild -d ../nrf/applications/connectivity_bridge/build-bl-update ../nrf/applications/connectivity_bridge -- -Dmcuboot_CONFIG_FW_INFO_FIRMWARE_VERSION=3 -DCONFIG_BUILD_S1_VARIANT=y
+          west build -b thingy91x/nrf5340/cpuapp -p --sysbuild -d ../nrf/applications/connectivity_bridge/build-bl-update ../nrf/applications/connectivity_bridge -- -Dmcuboot_CONFIG_FW_INFO_FIRMWARE_VERSION=4 -DCONFIG_BUILD_S1_VARIANT=y
           cp ../nrf/applications/connectivity_bridge/build-bl-update/dfu_mcuboot.zip \
             connectivity-bridge-${{ env.VERSION }}-thingy91x-nrf53-bootloader.zip
           cp ../nrf/applications/connectivity_bridge/build-bl-update/dfu_application.zip \

--- a/.github/workflows/dfu_check.yml
+++ b/.github/workflows/dfu_check.yml
@@ -89,8 +89,8 @@ jobs:
       - name: Build Connectivity Bridge
         working-directory: nrf/applications/connectivity_bridge
         run: |
-          west build -b thingy91x/nrf5340/cpuapp -p --sysbuild -- -Dmcuboot_CONFIG_FW_INFO_FIRMWARE_VERSION=2 -DCONFIG_BUILD_S1_VARIANT=y
-          west build -b thingy91x/nrf5340/cpuapp -p --sysbuild -d build-bl-update -- -Dmcuboot_CONFIG_FW_INFO_FIRMWARE_VERSION=3 -DCONFIG_BUILD_S1_VARIANT=y
+          west build -b thingy91x/nrf5340/cpuapp -p --sysbuild -- -Dmcuboot_CONFIG_FW_INFO_FIRMWARE_VERSION=3 -DCONFIG_BUILD_S1_VARIANT=y
+          west build -b thingy91x/nrf5340/cpuapp -p --sysbuild -d build-bl-update -- -Dmcuboot_CONFIG_FW_INFO_FIRMWARE_VERSION=4 -DCONFIG_BUILD_S1_VARIANT=y
 
       - name: 'nrf53: check partition layout'
         working-directory: nrf/applications/connectivity_bridge/build/
@@ -108,9 +108,9 @@ jobs:
       - name: 'nrf53: check bootloader image signature'
         working-directory: thingy91x-oob
         run: |
-          python3 scripts/nsib_signature_check.py -i ../nrf/applications/connectivity_bridge/build/signed_by_mcuboot_and_b0_mcuboot.hex -p verifying_key_nrf53.pem -a 0x00008200 -v 2
-          python3 scripts/nsib_signature_check.py -i ../nrf/applications/connectivity_bridge/build-bl-update/signed_by_mcuboot_and_b0_mcuboot.hex -p verifying_key_nrf53.pem -a 0x00008200 -v 3
-          python3 scripts/nsib_signature_check.py -i ../nrf/applications/connectivity_bridge/build-bl-update/signed_by_mcuboot_and_b0_s1_image.hex -p verifying_key_nrf53.pem -a 0x0001c200 -v 3
+          python3 scripts/nsib_signature_check.py -i ../nrf/applications/connectivity_bridge/build/signed_by_mcuboot_and_b0_mcuboot.hex -p verifying_key_nrf53.pem -a 0x00008200 -v 3
+          python3 scripts/nsib_signature_check.py -i ../nrf/applications/connectivity_bridge/build-bl-update/signed_by_mcuboot_and_b0_mcuboot.hex -p verifying_key_nrf53.pem -a 0x00008200 -v 4
+          python3 scripts/nsib_signature_check.py -i ../nrf/applications/connectivity_bridge/build-bl-update/signed_by_mcuboot_and_b0_s1_image.hex -p verifying_key_nrf53.pem -a 0x0001c200 -v 4
 
       - name: 'nrf53: check manifest slot indices'
         working-directory: thingy91x-oob

--- a/tests/on_target/tests/test_serial_dfu.py
+++ b/tests/on_target/tests/test_serial_dfu.py
@@ -159,7 +159,7 @@ def test_dfu(t91x_dfu):
     for _ in range(3):
         try:
             logger.info("Starting nRF53 BL DFU")
-            dfu_device(NRF53_BL_UPDATE_ZIP, serial=CONNECTIVITY_BRIDGE_UART)
+            dfu_device(NRF53_BL_UPDATE_ZIP, serial=CONNECTIVITY_BRIDGE_UART, bootloader_slot=0)
             wait_until_uart_available(CONNECTIVITY_BRIDGE_UART)
             break
         except Exception as e:
@@ -171,7 +171,7 @@ def test_dfu(t91x_dfu):
         raise Exception("Failed to perform nRF53 BL DFU after 3 attempts.")
 
     results = dfu_device(NRF53_BL_UPDATE_ZIP, serial=CONNECTIVITY_BRIDGE_UART, check_53_version=True)
-    # assert mcuboot slot 1 has correct version number 3
-    assert "S1: 3" in results
+    # assert mcuboot slot 0 has correct version number 4
+    assert "S0: 4" in results
 
     logger.info("nRF53 DFU successful")

--- a/tests/on_target/utils/flash_tools.py
+++ b/tests/on_target/utils/flash_tools.py
@@ -58,7 +58,7 @@ def recover_device(serial=SEGGER, core="Application"):
         logger.info(e.stderr)
         raise
 
-def dfu_device(zipfile, serial=None, reset_only=False, check_53_version=False):
+def dfu_device(zipfile, serial=None, reset_only=False, check_53_version=False, bootloader_slot=1):
     chip, is_mcuboot = detect_family_from_zip(zipfile)
     if chip is None:
         logger.error("Could not determine chip family from image")
@@ -68,6 +68,7 @@ def dfu_device(zipfile, serial=None, reset_only=False, check_53_version=False):
         'utils/thingy91x_dfu.py',
         '--image', zipfile,
         '--chip', chip,
+        '--bootloader-slot', str(bootloader_slot)
     ]
 
     if serial:

--- a/tests/on_target/utils/thingy91x_dfu.py
+++ b/tests/on_target/utils/thingy91x_dfu.py
@@ -394,7 +394,7 @@ def main():
     parser.add_argument("--vid", type=int, help="vendor id", default=0x1915)
     parser.add_argument("--pid", type=int, help="product id", default=0x910A)
     parser.add_argument("--serial", type=str, help="serial number", default=None)
-    parser.add_argument("--bootloader_slot", type=int, help="bootloader slot", default=1)
+    parser.add_argument("--bootloader-slot", type=int, help="bootloader slot", default=1)
     args = parser.parse_args()
 
     chip = args.chip


### PR DESCRIPTION
The bootloader version we want to use for production is actually 3, not 2. The test is updated to reflect this.
Also, the currently used slot is 1, so the update should go to slot 0.