### PR TITLE
workflows: revert memfault sw type and debug build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,6 @@ jobs:
     secrets: inherit
     with:
       build_bl_update: true
-      build_debug: true
-      memfault_sw_type: "hello.nrfcloud.com"
   dfu_check:
     uses: ./.github/workflows/dfu_check.yml
     needs: build


### PR DESCRIPTION
CI build should use default "hello.nrfcloud.com-ci". Otherwise is we are not able to distinguish in memfault UI. And CI will just spam it.
Also, debug build is not needed for normal CI, only release.