### PR TITLE
tests: on_target: use dfu instead of segger

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -144,7 +144,7 @@ jobs:
             --junit-xml=results/test-results-uart.xml \
             tests
         env:
-          SEGGER: ${{ secrets.SEGGER_DUT_1 }}
+          T91X_SERIAL_NUMBER: ${{ secrets.SEGGER_DUT_1 }}
           LOG_FILENAME: oob_uart_test_log
 
       - name: Run FOTA tests (standard)
@@ -155,9 +155,9 @@ jobs:
             --junit-xml=results/test-results-fota.xml \
             tests
         env:
-          SEGGER: ${{ secrets.SEGGER_DUT_1 }}
-          IMEI: ${{ secrets.IMEI_DUT_1 }}
-          FINGERPRINT: ${{ secrets.FINGERPRINT_DUT_1 }}
+          T91X_SERIAL_NUMBER: ${{ secrets.NRFUTIL_ID_DUT_1 }}
+          T91X_IMEI: ${{ secrets.IMEI_DUT_1 }}
+          T91X_FINGERPRINT: ${{ secrets.FINGERPRINT_DUT_1 }}
           LOG_FILENAME: oob_fota_test_log
 
       - name: Run FOTA tests (FULLMFW)
@@ -168,9 +168,9 @@ jobs:
             --junit-xml=results/test-results-fullmfw-fota.xml \
             tests
         env:
-          SEGGER: ${{ secrets.SEGGER_DUT_1 }}
-          IMEI: ${{ secrets.IMEI_DUT_1 }}
-          FINGERPRINT: ${{ secrets.FINGERPRINT_DUT_1 }}
+          T91X_SERIAL_NUMBER: ${{ secrets.NRFUTIL_ID_DUT_1 }}
+          T91X_IMEI: ${{ secrets.IMEI_DUT_1 }}
+          T91X_FINGERPRINT: ${{ secrets.FINGERPRINT_DUT_1 }}
           LOG_FILENAME: oob_fullmfw_fota_test_log
 
       - name: Run DFU tests

--- a/tests/on_target/README.md
+++ b/tests/on_target/README.md
@@ -42,7 +42,7 @@ nrfutil device list
 Precondition: thingy91x with segger fw on 53
 
 ```shell
-export SEGGER=<your_segger>
+export T91X_SERIAL_NUMBER=<your_t91x_serial_number>
 pytest -s -v -m "dut1 and uart" tests
 ```
 
@@ -51,9 +51,9 @@ pytest -s -v -m "dut1 and uart" tests
 Precondition: thingy91x with segger fw on 53
 
 ```shell
-export SEGGER=<your_segger>
-export IMEI=<your_imei>
-export FINGERPRINT=<your_fingerprint>
+export T91X_SERIAL_NUMBER=<your_t91x_serial_number>
+export T91X_IMEI=<your_t91x_imei>
+export T91X_FINGERPRINT=<your_t91x_fingerprint>
 pytest -s -v -m "dut1 and fota" tests
 ```
 

--- a/tests/on_target/tests/test_fota.py
+++ b/tests/on_target/tests/test_fota.py
@@ -51,10 +51,11 @@ def run_fota_resumption(t91x_board, fota_type):
 @pytest.fixture
 def run_fota_fixture(t91x_board, hex_file):
     def _run_fota(bundleId, fota_type, fotatimeout=APP_FOTA_TIMEOUT, test_fota_resumption=False):
-        flash_device(os.path.abspath(hex_file))
+        flash_device(serial=t91x_board.serial_number, hexfile=os.path.abspath(hex_file))
+        time.sleep(10)
         t91x_board.uart.xfactoryreset()
         t91x_board.uart.flush()
-        reset_device()
+        reset_device(serial=t91x_board.serial_number)
         t91x_board.uart.wait_for_str("Connected to Cloud")
 
         job_id = post_job(t91x_board, bundleId, fota_type)
@@ -77,7 +78,7 @@ def run_fota_fixture(t91x_board, hex_file):
 
 @pytest.mark.dut1
 @pytest.mark.fota
-def test_app_fota(t91x_board, hex_file, run_fota_fixture):
+def test_app_fota(t91x_board, run_fota_fixture):
     # Get latest APP fota bundle
     results = t91x_board.fota.get_fota_bundles()
     if not results:
@@ -96,18 +97,17 @@ def test_app_fota(t91x_board, hex_file, run_fota_fixture):
 
 @pytest.mark.dut1
 @pytest.mark.fota
-def test_delta_mfw_fota(t91x_board, hex_file, run_fota_fixture):
+def test_delta_mfw_fota(t91x_board, run_fota_fixture):
     # Flash with mfw201
-    flash_device(os.path.abspath(MFW_201_FILEPATH))
+    flash_device(serial=t91x_board.serial_number, hexfile=os.path.abspath(MFW_201_FILEPATH))
 
-    # run_fota(DELTA_MFW_BUNDLEID, hex_file)
     run_fota_fixture(DELTA_MFW_BUNDLEID, "delta")
 
     # Restore mfw201
-    flash_device(os.path.abspath(MFW_201_FILEPATH))
+    flash_device(serial=t91x_board.serial_number, hexfile=os.path.abspath(MFW_201_FILEPATH))
 
 
 @pytest.mark.dut1
 @pytest.mark.fullmfw_fota
-def test_full_mfw_fota(t91x_board, hex_file, run_fota_fixture):
+def test_full_mfw_fota(run_fota_fixture):
     run_fota_fixture(FULL_MFW_BUNDLEID, "full", FULL_MFW_FOTA_TIMEOUT)

--- a/tests/on_target/tests/test_location.py
+++ b/tests/on_target/tests/test_location.py
@@ -23,7 +23,8 @@ def test_gnss_location(t91x_board, hex_file):
     run_location(t91x_board, hex_file, location_method="GNSS")
 
 def run_location(t91x_board, hex_file, location_method):
-    flash_device(os.path.abspath(hex_file))
+    flash_device(serial=t91x_board.serial_number, hexfile=os.path.abspath(hex_file))
+    time.sleep(5)
     t91x_board.uart.xfactoryreset()
     patterns_cloud_connection = [
             "Network connectivity established",
@@ -37,7 +38,7 @@ def run_location(t91x_board, hex_file, location_method):
 
     # Cloud connection
     t91x_board.uart.flush()
-    reset_device()
+    reset_device(serial=t91x_board.serial_number)
     t91x_board.uart.wait_for_str(patterns_cloud_connection, timeout=60)
 
     # Location

--- a/tests/on_target/tests/test_uart_output.py
+++ b/tests/on_target/tests/test_uart_output.py
@@ -17,7 +17,8 @@ logger = get_logger()
 @pytest.mark.dut1
 @pytest.mark.uart
 def test_uart_output(t91x_board, hex_file):
-    flash_device(os.path.abspath(hex_file))
+    flash_device(serial=t91x_board.serial_number, hexfile=os.path.abspath(hex_file))
+    time.sleep(5)
     t91x_board.uart.xfactoryreset()
     patterns_boot = [
             "Network connectivity established",
@@ -41,7 +42,7 @@ def test_uart_output(t91x_board, hex_file):
 
     # Boot
     t91x_board.uart.flush()
-    reset_device()
+    reset_device(serial=t91x_board.serial_number)
     t91x_board.uart.wait_for_str(patterns_boot, timeout=120)
 
     # Button press

--- a/tests/on_target/utils/flash_tools.py
+++ b/tests/on_target/utils/flash_tools.py
@@ -12,9 +12,8 @@ from utils.thingy91x_dfu import detect_family_from_zip
 
 logger = get_logger()
 
-SEGGER = os.getenv('SEGGER')
 
-def reset_device(serial=SEGGER, reset_kind="RESET_SYSTEM"):
+def reset_device(serial=None, reset_kind="RESET_SYSTEM"):
     logger.info(f"Resetting device, segger: {serial}")
     try:
         result = subprocess.run(
@@ -31,7 +30,7 @@ def reset_device(serial=SEGGER, reset_kind="RESET_SYSTEM"):
         logger.info(e.stderr)
         raise
 
-def flash_device(hexfile, serial=SEGGER, extra_args=[]):
+def flash_device(serial=None, hexfile=None, extra_args=[]):
     # hexfile (str): Full path to file (hex or zip) to be programmed
     logger.info(f"Flashing device, segger: {serial}, firmware: {hexfile}")
     try:
@@ -46,7 +45,7 @@ def flash_device(hexfile, serial=SEGGER, extra_args=[]):
 
     reset_device(serial)
 
-def recover_device(serial=SEGGER, core="Application"):
+def recover_device(serial=None, core="Application"):
     logger.info(f"Recovering device, segger: {serial}")
     try:
         result = subprocess.run(['nrfutil', 'device', 'recover', '--serial-number', serial, '--core', core], check=True, text=True, capture_output=True)
@@ -58,7 +57,7 @@ def recover_device(serial=SEGGER, core="Application"):
         logger.info(e.stderr)
         raise
 
-def dfu_device(zipfile, serial=None, reset_only=False, check_53_version=False, bootloader_slot=1):
+def dfu_device(serial=None, zipfile=None, reset_only=False, check_53_version=False, bootloader_slot=1):
     chip, is_mcuboot = detect_family_from_zip(zipfile)
     if chip is None:
         logger.error("Could not determine chip family from image")


### PR DESCRIPTION
Use dfu default flashing for all tests, instead of segger on 53.