### PR TITLE
modules: shell: Add wait before UARTs are suspended

### DIFF
--- a/app/src/modules/shell/shell.c
+++ b/app/src/modules/shell/shell.c
@@ -67,6 +67,12 @@ static void uart_disable_handler(struct k_work *work)
 	}
 #endif
 
+	/* Wait for UART buffers to be emptied before suspending.
+	 * If a transfer is ongoing, the driver will cause an assertion to fail.
+	 * 100 ms is an arbitrary value that should be enough for the buffers to empty.
+	 */
+	k_busy_wait(100 * USEC_PER_MSEC);
+
 	if (device_is_ready(uart1_dev)) {
 		pm_device_action_run(uart1_dev, PM_DEVICE_ACTION_SUSPEND);
 	}


### PR DESCRIPTION
Add a short wait before UARTs are suspended to leave time to empty the buffers. Otherwise an assert will kick in because the TX_STOPPED event has not been received before suspending the UARTs.