### PR TITLE
workflows: dont build for on_target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "tests/on_target/**"
   pull_request:
+    paths-ignore:
+      - "tests/on_target/**"
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
There is no need to build when on_target files are modified.