### PR TITLE
workflows: on_target: continue on error, commit badge

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -236,6 +236,7 @@ jobs:
 
       - name: Commit and Push Badge File to gh-pages Branch
         if: ${{ inputs.run_ppk_tests }}
+        continue-on-error: true
         working-directory: thingy91x-oob
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
If commit of ppk badge fails, do not mark the whole job as failed.