### PR TITLE
workflows: on_target: commit ppk badge always

### DIFF
--- a/.github/workflows/on_target.yml
+++ b/.github/workflows/on_target.yml
@@ -121,6 +121,7 @@ jobs:
           MEMFAULT_PROJECT_SLUG: ${{ vars.MEMFAULT_PROJECT_SLUG }}
 
       - name: Commit and Push Badge File to gh-pages Branch
+        if: always()
         continue-on-error: true
         working-directory: thingy91x-oob
         env:

--- a/tests/on_target/scripts/commit_badge.sh
+++ b/tests/on_target/scripts/commit_badge.sh
@@ -15,15 +15,15 @@ CSV_FILE_DEST=docs/power_measurements.csv
 # Check if files exist
 if [ ! -f $BADGE_FILE ]; then
   echo "Badge file not found: $BADGE_FILE"
-  exit 1
+  exit 0
 fi
 if [ ! -f $HTML_FILE ]; then
   echo "HTML file not found: $HTML_FILE"
-  exit 1
+  exit 0
 fi
 if [ ! -f $CSV_FILE ]; then
   echo "CSV file not found: $CSV_FILE"
-  exit 1
+  exit 0
 fi
 
 # Configure Git


### PR DESCRIPTION
Currently badge does not get committed if previous tests fail. Always commit it, script exits without fail if no file is found.