### PR TITLE
workflows: Fix doc build copy step

### DIFF
--- a/.github/workflows/docs-build-and-publish.yml
+++ b/.github/workflows/docs-build-and-publish.yml
@@ -63,7 +63,6 @@ jobs:
 
           # Update docs
           rm -rf docs/html
-          mkdir docs/html
           cp -r docs/build/html docs/html
           rm -rf docs/build
 


### PR DESCRIPTION
Fix the copy step so that we don't end up with 'html/html/'.