### PR TITLE
Docs: Add introduction

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - ".github/workflows/docs-build-and-publish.yml"
+      - "docs/**"
   pull_request_target:
     paths:
       - '**/*.c'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - ".github/workflows/docs-build-and-publish.yml"
+      - "docs/**"
 jobs:
   build:
     uses: ./.github/workflows/build.yml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,11 +3,22 @@
 Thingy:91 X: Hello nRF Cloud firmware
 #####################################
 
-.. contents::
-   :local:
-   :depth: 2
+The Hello nRF Cloud firmware is the official, factory-programmed firmware for the nRF9151 SiP on the Thingy:91 X device.
 
-This project is based on the `NCS Example Application`_.
+The application search for and connects to an LTE network and sends network and sensor data to nRF Cloud, using CoAP over UDP as transport protocol.
+Sampled data that is sent from the application, can be viewed in the `hello.nrfcloud.com`_ web interface.
+
+Some of the key features of the firmware include:
+
+* LTE network connection management
+* Secure and efficient communication with nRF Cloud using CoAP with DTLS connection ID over UDP
+* Sensor data collection and transmission
+* Firmware-Over-the-Air (FOTA) capability for application and modem updates
+* Modem tracing capability
+* LED indication for visualizing the operating state of the application
+
+The project repository is based on the `NCS Example Application`_ and customized to the needs of the application.
+Read more about the various aspects of the firmware in the following sections.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/links.txt
+++ b/docs/links.txt
@@ -32,3 +32,5 @@
 .. _`Interactive BOM PCA20065 1.0.0.`: https://htmlpreview.github.io/?https://github.com/hello-nrfcloud/firmware/blob/main/docs/pca20065_1_0_0.html
 
 .. _`pyOCD`: https://github.com/pyocd/pyOCD
+
+.. _`hello.nrfcloud.com`: https://hello.nrfcloud.com/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 Sphinx==5.3.0
 breathe==4.35.0
-sphinx-ncs-theme<=0.7.4
+sphinx-ncs-theme==0.7.4
 sphinx-tabs>=3.4
 sphinx-togglebutton>=0.3.2
 Pillow>=9.0.1


### PR DESCRIPTION
* Add introduction section to the documentation.

* Skip the Sonarcloud checks and build jobs when only docs have changed.