### PR TITLE
tests: on_target: relax test timeouts

### DIFF
--- a/tests/on_target/tests/test_functional/test_location.py
+++ b/tests/on_target/tests/test_functional/test_location.py
@@ -43,7 +43,7 @@ def run_location(t91x_board, hex_file, location_method):
     # Cloud connection
     t91x_board.uart.flush()
     reset_device()
-    t91x_board.uart.wait_for_str(patterns_cloud_connection, timeout=60)
+    t91x_board.uart.wait_for_str(patterns_cloud_connection, timeout=120)
 
     # Location
     t91x_board.uart.wait_for_str(patterns_location, timeout=180)

--- a/tests/on_target/tests/test_functional/test_memfault.py
+++ b/tests/on_target/tests/test_functional/test_memfault.py
@@ -81,7 +81,7 @@ def test_memfault(t91x_board, hex_file):
 
     t91x_board.uart.flush()
     reset_device()
-    t91x_board.uart.wait_for_str(patterns_memfault, timeout=60)
+    t91x_board.uart.wait_for_str(patterns_memfault, timeout=120)
 
     # Trigger bus fault to generate memfault event
     t91x_board.uart.write("mflt test busfault\r\n")


### PR DESCRIPTION
Relax timeouts to reduce CI instabilities.