### PR TITLE
docs: Restructure about section to two separate pages

### DIFF
--- a/docs/bom.rst
+++ b/docs/bom.rst
@@ -1,0 +1,6 @@
+.. _thingy91_x_helloworld_firmware_bom:
+
+Bill of materials (BOM)
+***********************
+
+You can explore the interactive BOM for the Thingy:91 X board online on `Interactive BOM PCA20065 1.0.0.`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,7 @@ Thingy:91 X: Hello nRF Cloud firmware
 #####################################
 
 The Hello nRF Cloud firmware is the official, factory-programmed firmware for the nRF9151 SiP on the Thingy:91 X device.
+The latest release of the firmware is available for download from `Thingy:91 X firmware releases <github_release_>`_, where you can also find the factory-programmed `Connectivity Bridge`_ for the nRF5340 SoC on the device.
 
 The application searches for and connects to an LTE network and sends network and sensor data to nRF Cloud, using CoAP over UDP as the transport protocol.
 Sampled data that is sent from the application can be viewed in the `hello.nrfcloud.com`_ web interface.
@@ -25,9 +26,10 @@ Read more about the various aspects of the firmware in the following sections.
    :caption: Contents
    :glob:
 
-   about
    gsg_guide
    architecture
+   led_indication
    troubleshooting
    known_issues
    release_notes
+   bom

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -18,3 +18,15 @@ Serial DFU stops working after using GNU screen
   **Workaround:** Use a different serial terminal application, for example, `Serial Terminal app`_, ``tio`` or, power cycle device, if needed.
 
   **Affected platforms:** Thingy:91 X
+
+v2-0-0 v2-0-1
+
+FOTA image downloads may fail to resume correctly after a network disconnection
+   FOTA image downloads may fail to resume correctly after a network disconnection.
+   The downloader may use the wrong byte offset when requesting file fragments, which results in a corrupted image being downloaded.
+   The image will be rejected by the bootloader, and will not harm the device.
+   After a failed download, the device will attempt to download the image again.
+
+  **Workaround:** Disable the :kconfig:option`CONFIG_NRF_CLOUD_COAP_DOWNLOADS` Kconfig option in the application configuration.
+
+  **Affected platforms:** Thingy:91 X

--- a/docs/led_indication.rst
+++ b/docs/led_indication.rst
@@ -1,17 +1,11 @@
 .. _thingy91_x_helloworld_firmware_about:
 
-About Thingy:91 X: Hello nRF Cloud firmware
-###########################################
+LED indication
+##############
 
 .. contents::
    :local:
-   :depth: 1
-
-This project is based on the `NCS Example Application`_.
-The project contains the firmware that is programmed on the Thingy:91 X in the factory.
-
-LED indication
-**************
+   :depth: 2
 
 The firmware supports multiple LED patterns to visualize the operating state of the application.
 The following table describes the supported LED states:
@@ -33,8 +27,3 @@ The following table describes the supported LED states:
 +----------------+------------+----------------------------------------------+-----------------------------------------------------+
 | Blinking slow  | Red        | Irrecoverable fatal error                    | NA                                                  |
 +----------------+------------+----------------------------------------------+-----------------------------------------------------+
-
-Interactive bill of materials (BOM)
-***********************************
-
-You can explore the interactive BOM for the Thingy:91 X board online on `Interactive BOM PCA20065 1.0.0.`_

--- a/docs/links.txt
+++ b/docs/links.txt
@@ -14,6 +14,7 @@
 .. _`Serial Terminal app`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html
 .. _`Getting started guide`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation.html
 .. _`nRF Util`: https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html
+.. _`Connectivity Bridge`: https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/connectivity_bridge/README.html
 
 .. ### github.com
 


### PR DESCRIPTION
The about section is covered on the front page and is now reduntant. Move the LED indication info and BOM to separate pages.

Also, add a link to releases on the front page.