### PR TITLE
app: boards: Fix LED color swap

### DIFF
--- a/app/src/modules/led/led_pwm.c
+++ b/app/src/modules/led/led_pwm.c
@@ -104,14 +104,14 @@ static int pwm_out(const struct led_color *color)
 	}
 
 	/* GREEN */
-	err = pwm_set_dt(&led2, PWM_USEC(LED_MAX), PWM_USEC(color->c[1]));
+	err = pwm_set_dt(&led1, PWM_USEC(LED_MAX), PWM_USEC(color->c[1]));
 	if (err) {
 		LOG_ERR("pwm_set_dt, error:%d", err);
 		return err;
 	}
 
 	/* BLUE */
-	err = pwm_set_dt(&led1, PWM_USEC(LED_MAX), PWM_USEC(color->c[2]));
+	err = pwm_set_dt(&led2, PWM_USEC(LED_MAX), PWM_USEC(color->c[2]));
 	if (err) {
 		LOG_ERR("pwm_set_dt, error:%d", err);
 		return err;


### PR DESCRIPTION
Fix G and B color swap in the RGB PWM configuration. This can be removed when it is corrected in sdk-nrf.