### PR TITLE
ci: fix documentation build

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -37,8 +37,9 @@ jobs:
           python-version: 3.14
           cache: pip
           cache-dependency-path: docs/requirements.txt
-          pip-install: |
-            -r docs/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
 
       - name: Build
         working-directory: docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==5.3.0
+Sphinx>=9
 breathe==4.35.0
 sphinx-ncs-theme<2.1
 sphinx-tabs>=3.4


### PR DESCRIPTION
Two independent regressions broke the documentation build:

- actions/setup-python v7 removed the `pip-install` input, so the docs requirements were never installed and `sphinx-build` was not found (exit 127). Install them in an explicit step instead.
- Sphinx 5.3.0 cannot run on Python 3.13+ because `imghdr` was removed from the stdlib, making `sphinx.builders.epub3` fail to import. Unpin Sphinx so a compatible version (9.x) is used.

Verified locally: docs build succeeds with Sphinx 9.1.0 on Python 3.14.7.